### PR TITLE
Add default seccomp profile to containers

### DIFF
--- a/bundlegen/core/bundle_processor.py
+++ b/bundlegen/core/bundle_processor.py
@@ -40,7 +40,7 @@ class BundleProcessor:
         self.libmatcher = LibraryMatching(
             self.platform_cfg, self.bundle_path, self._add_bind_mount, nodepwalking, libmatchingmode, createmountpoints)
 
-        self.seccomp = Seccomp(self.platform_cfg, self.oci_config)
+        self.seccomp = Seccomp(self.platform_cfg, self.app_metadata, self.oci_config)
 
     # Umoci will produce a config based on a "good, sane default" configuration
     # as defined here: https://github.com/opencontainers/umoci/blob/master/oci/config/convert/default.go
@@ -608,10 +608,7 @@ class BundleProcessor:
 
     # ==========================================================================
     def _process_seccomp(self):
-        """Just adds the rdkplugins section ready to be populated
-
-        Also adds a mount for the Dobby plugin directory so the startContainer
-        hook can load them
+        """Adds a seccomp profile to the container config
         """
         self.seccomp.enable_seccomp()
 

--- a/bundlegen/core/bundle_processor.py
+++ b/bundlegen/core/bundle_processor.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from bundlegen.core.utils import Utils
 from bundlegen.core.library_matching import LibraryMatching
 from bundlegen.core.capabilities import *
+from bundlegen.core.seccomp import Seccomp
 
 
 class BundleProcessor:
@@ -38,6 +39,8 @@ class BundleProcessor:
         self.oci_config: dict = self.load_config()
         self.libmatcher = LibraryMatching(
             self.platform_cfg, self.bundle_path, self._add_bind_mount, nodepwalking, libmatchingmode, createmountpoints)
+
+        self.seccomp = Seccomp(self.platform_cfg, self.oci_config)
 
     # Umoci will produce a config based on a "good, sane default" configuration
     # as defined here: https://github.com/opencontainers/umoci/blob/master/oci/config/convert/default.go
@@ -71,6 +74,7 @@ class BundleProcessor:
         self._process_users_and_groups()
         self._process_capabilities()
         self._process_hostname()
+        self._process_seccomp()
 
         # RDK Plugins section
         self._add_rdk_plugins()
@@ -601,6 +605,16 @@ class BundleProcessor:
         cfg_caps['effective'] = list(app_capabilities)
         cfg_caps['inheritable'] = list(app_capabilities)
         cfg_caps['ambient'] = list(app_capabilities)
+
+    # ==========================================================================
+    def _process_seccomp(self):
+        """Just adds the rdkplugins section ready to be populated
+
+        Also adds a mount for the Dobby plugin directory so the startContainer
+        hook can load them
+        """
+        self.seccomp.enable_seccomp()
+
 
     # ==========================================================================
     def _add_rdk_plugins(self):

--- a/bundlegen/core/seccomp.py
+++ b/bundlegen/core/seccomp.py
@@ -1,0 +1,148 @@
+# If not stated otherwise in this file or this component's license file the
+# following copyright and licenses apply:
+#
+# Copyright 2020 Consult Red
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import json
+from loguru import logger
+
+# By default, we include the default seccomp profile by Docker/Moby
+# https://github.com/moby/moby/tree/master/profiles/seccomp
+#
+# This is designed to offer a reasonable compatability/security tradeoff
+# The rationale behind blocked syscalls is documented here:
+# https://docs.docker.com/engine/security/seccomp/
+
+
+class Seccomp:
+    def __init__(self, platform_cfg, oci_config):
+        self.platform_cfg = platform_cfg
+        self.oci_config = oci_config
+
+        # Load seccomp profile from default.json (hardcoded for now)
+        dirname = os.path.dirname(__file__)
+        self.seccomp_profile = {}
+        with open(os.path.join(dirname, '../profiles/seccomp/default.json')) as default_profile:
+            self.seccomp_profile = json.load(default_profile)
+
+        # map architecture string to seccomp arch used in runtime spec
+        self.libseccomp_map = {
+            "x86":         "SCMP_ARCH_X86",
+            "amd64":       "SCMP_ARCH_X86_64",
+            "arm":         "SCMP_ARCH_ARM",
+            "arm64":       "SCMP_ARCH_AARCH64",
+            "mips64":      	"SCMP_ARCH_MIPS64",
+            "mips64n32":   	"SCMP_ARCH_MIPS64N32",
+            "mipsel64":    "SCMP_ARCH_MIPSEL64",
+            "mips3l64n32": "SCMP_ARCH_MIPSEL64N32",
+            "mipsle":      "SCMP_ARCH_MIPSEL",
+            "ppc":         "SCMP_ARCH_PPC",
+            "ppc64":       "SCMP_ARCH_PPC64",
+            "ppc64le":     "SCMP_ARCH_PPC64LE",
+            "s390":        "SCMP_ARCH_S390",
+            "s390x":       "SCMP_ARCH_S390X"
+        }
+
+    def parse_kernel(self, kernel_version):
+        parts = kernel_version.split(".", maxsplit=2)
+        if len(parts) < 2:
+            logger.error(
+                f"AInvalid kernel version: {kernel_version}, expected '<kernel>.<major>'")
+            return False
+
+        if not parts[0].isdigit() or not parts[1].isdigit():
+            logger.error(
+                f"BInvalid kernel version: {kernel_version}, expected '<kernel>.<major>'")
+            return False
+
+        return (parts[0], parts[1])
+
+    def _kernel_version_greater_or_equal(self, min_version, kernel_version):
+        if kernel_version[0] > min_version[0]:
+            return True
+        if kernel_version[0] == min_version[0] and kernel_version[1] >= min_version[1]:
+            return True
+
+        return False
+
+    def enable_seccomp(self):
+        """
+        Enables seccomp for a container. Uses the loaded profile to block
+        specific system calls
+        """
+        # First, we need to know the kernel version of the platform
+        # Ignore minor revisions or host-specific suffixes
+        platform_kernel = self.platform_cfg.get("kernel")
+        if platform_kernel is None:
+            logger.error("Cannot enable seccomp - unknown kernel version")
+            return False
+
+        kernel_version = self.parse_kernel(platform_kernel)
+        logger.info(
+            f"Kernel version is {kernel_version[0]}.{kernel_version[1]}")
+
+        # validate the seccomp profile
+        cfg = self.seccomp_profile
+        if cfg.get("defaultAction") is None and len(cfg.get("syscalls")) == 0:
+            logger.info("No default action or syscalls - cannot setup seccomp")
+
+        platform_arch = self.platform_cfg["arch"]["arch"]
+
+        # Construct the seccomp section of the OCI runtime config
+        spec_cfg = {}
+        spec_cfg["defaultAction"] = cfg["defaultAction"]
+        spec_cfg["architectures"] = []
+        spec_cfg["architectures"].append(
+            self.libseccomp_map.get(platform_arch))
+        spec_cfg["syscalls"] = []
+
+        logger.info(spec_cfg)
+
+        for syscall in cfg["syscalls"]:
+            if syscall["excludes"].get("arches"):
+                if platform_arch in syscall["excludes"]["arches"]:
+                    continue
+
+            if syscall["excludes"].get("caps"):
+                if any(cap in self.oci_config["process"]["capabilities"]["bounding"] for cap in syscall["excludes"]["caps"]):
+                    continue
+
+            if syscall["excludes"].get("minKernel"):
+                if self._kernel_version_greater_or_equal(self.parse_kernel(syscall["excludes"].get("minKernel")), kernel_version):
+                    continue
+
+            if syscall["includes"].get("arches"):
+                if not platform_arch in syscall["includes"]["arches"]:
+                    continue
+
+            if syscall["includes"].get("caps"):
+                if not any(cap in self.oci_config["process"]["capabilities"]["bounding"] for cap in syscall["includes"]["caps"]):
+                    continue
+
+            if syscall["includes"].get("minKernel"):
+                if not self._kernel_version_greater_or_equal(self.parse_kernel(syscall["includes"].get("minKernel")), kernel_version):
+                    continue
+            
+            # Finally, a valid rule! 
+            spec_cfg["syscalls"].append({
+                "names": syscall["names"],
+                "action": syscall["action"],
+                "args": syscall["args"]
+            })
+
+        # Done, append this to the OCI config
+        logger.info("Created seccomp rules")
+        self.oci_config["linux"]["seccomp"] = spec_cfg

--- a/bundlegen/core/seccomp.py
+++ b/bundlegen/core/seccomp.py
@@ -28,15 +28,35 @@ from loguru import logger
 
 
 class Seccomp:
-    def __init__(self, platform_cfg, oci_config):
+    def __init__(self, platform_cfg, app_metadata, oci_config):
         self.platform_cfg = platform_cfg
+        self.app_metadata = app_metadata
         self.oci_config = oci_config
+        self.valid = True
 
-        # Load seccomp profile from default.json (hardcoded for now)
-        dirname = os.path.dirname(__file__)
-        self.seccomp_profile = {}
-        with open(os.path.join(dirname, '../profiles/seccomp/default.json')) as default_profile:
-            self.seccomp_profile = json.load(default_profile)
+        # Load seccomp profile
+        if app_metadata.get('seccomp') and app_metadata['seccomp'].get('allow'):
+            # If app has a specific whitelist, use that to build a profie
+            self.seccomp_profile = self.build_app_profile()
+        elif platform_cfg.get('seccomp') and platform_cfg['seccomp'].get('profile'):
+            # Use platform-specific seccomp profie
+            custom_profile = platform_cfg['seccomp']['profile']
+
+            if not os.path.exists(custom_profile):
+                logger.error(
+                    f"Could not find seccomp profile @ '{custom_profile}'")
+                valid = False
+
+            logger.info(
+                f"Loading custom seccomp profile for platform from {custom_profile}")
+            with open(custom_profile) as profile:
+                self.seccomp_profile = json.load(profile)
+        else:
+            # Use default profile
+            dirname = os.path.dirname(__file__)
+            self.seccomp_profile = {}
+            with open(os.path.join(dirname, '../profiles/seccomp/default.json')) as default_profile:
+                self.seccomp_profile = json.load(default_profile)
 
         # map architecture string to seccomp arch used in runtime spec
         self.libseccomp_map = {
@@ -56,21 +76,41 @@ class Seccomp:
             "s390x":       "SCMP_ARCH_S390X"
         }
 
+    def build_app_profile(self):
+        """
+        Creates a simple seccomp profile based on a list of allowed syscalls in the app metadata"""
+        logger.info("Creating custom seccomp profile for application")
+
+        allowed_syscalls = self.app_metadata['seccomp']['allow']
+
+        dirname = os.path.dirname(__file__)
+        base_profile = {}
+        with open(os.path.join(dirname, '../profiles/seccomp/base.json')) as base_profile:
+            base_profile = json.load(base_profile)
+
+        base_profile['syscalls'][0]['names'] = allowed_syscalls
+
+        return base_profile
+
     def parse_kernel(self, kernel_version):
+        """
+        Return the major/minor kernel version numbers as ints"""
         parts = kernel_version.split(".", maxsplit=2)
         if len(parts) < 2:
             logger.error(
-                f"AInvalid kernel version: {kernel_version}, expected '<kernel>.<major>'")
+                f"Invalid kernel version: {kernel_version}, expected '<kernel>.<major>'")
             return False
 
         if not parts[0].isdigit() or not parts[1].isdigit():
             logger.error(
-                f"BInvalid kernel version: {kernel_version}, expected '<kernel>.<major>'")
+                f"Invalid kernel version: {kernel_version}, expected '<kernel>.<major>'")
             return False
 
         return (parts[0], parts[1])
 
     def _kernel_version_greater_or_equal(self, min_version, kernel_version):
+        """
+        Checks if the provided kernel version is >= a minimum version"""
         if kernel_version[0] > min_version[0]:
             return True
         if kernel_version[0] == min_version[0] and kernel_version[1] >= min_version[1]:
@@ -83,66 +123,81 @@ class Seccomp:
         Enables seccomp for a container. Uses the loaded profile to block
         specific system calls
         """
+        if not self.valid:
+            logger.error("Cannot enable seccomp - not in a valid state")
+            return False
+
         # First, we need to know the kernel version of the platform
         # Ignore minor revisions or host-specific suffixes
         platform_kernel = self.platform_cfg.get("kernel")
         if platform_kernel is None:
-            logger.error("Cannot enable seccomp - unknown kernel version")
+            logger.warning(
+                "Cannot enable seccomp - kernel version not set in platform template")
             return False
 
         kernel_version = self.parse_kernel(platform_kernel)
-        logger.info(
+        logger.debug(
             f"Kernel version is {kernel_version[0]}.{kernel_version[1]}")
 
         # validate the seccomp profile
         cfg = self.seccomp_profile
         if cfg.get("defaultAction") is None and len(cfg.get("syscalls")) == 0:
             logger.info("No default action or syscalls - cannot setup seccomp")
+            return False
 
         platform_arch = self.platform_cfg["arch"]["arch"]
 
         # Construct the seccomp section of the OCI runtime config
         spec_cfg = {}
         spec_cfg["defaultAction"] = cfg["defaultAction"]
+        spec_cfg["defaultErrnoRet"] = cfg["defaultErrnoRet"]
         spec_cfg["architectures"] = []
         spec_cfg["architectures"].append(
             self.libseccomp_map.get(platform_arch))
         spec_cfg["syscalls"] = []
 
-        logger.info(spec_cfg)
-
         for syscall in cfg["syscalls"]:
-            if syscall["excludes"].get("arches"):
-                if platform_arch in syscall["excludes"]["arches"]:
-                    continue
+            if syscall.get('excludes'):
+                if syscall["excludes"].get("arches"):
+                    if platform_arch in syscall["excludes"]["arches"]:
+                        continue
 
-            if syscall["excludes"].get("caps"):
-                if any(cap in self.oci_config["process"]["capabilities"]["bounding"] for cap in syscall["excludes"]["caps"]):
-                    continue
+                if syscall["excludes"].get("caps"):
+                    if any(cap in self.oci_config["process"]["capabilities"]["bounding"] for cap in syscall["excludes"]["caps"]):
+                        continue
 
-            if syscall["excludes"].get("minKernel"):
-                if self._kernel_version_greater_or_equal(self.parse_kernel(syscall["excludes"].get("minKernel")), kernel_version):
-                    continue
+                if syscall["excludes"].get("minKernel"):
+                    if self._kernel_version_greater_or_equal(self.parse_kernel(syscall["excludes"].get("minKernel")), kernel_version):
+                        continue
 
-            if syscall["includes"].get("arches"):
-                if not platform_arch in syscall["includes"]["arches"]:
-                    continue
+            if syscall.get('includes'):
+                if syscall["includes"].get("arches"):
+                    if not platform_arch in syscall["includes"]["arches"]:
+                        continue
 
-            if syscall["includes"].get("caps"):
-                if not any(cap in self.oci_config["process"]["capabilities"]["bounding"] for cap in syscall["includes"]["caps"]):
-                    continue
+                if syscall["includes"].get("caps"):
+                    if not any(cap in self.oci_config["process"]["capabilities"]["bounding"] for cap in syscall["includes"]["caps"]):
+                        continue
 
-            if syscall["includes"].get("minKernel"):
-                if not self._kernel_version_greater_or_equal(self.parse_kernel(syscall["includes"].get("minKernel")), kernel_version):
-                    continue
-            
-            # Finally, a valid rule! 
-            spec_cfg["syscalls"].append({
+                if syscall["includes"].get("minKernel"):
+                    if not self._kernel_version_greater_or_equal(self.parse_kernel(syscall["includes"].get("minKernel")), kernel_version):
+                        continue
+
+            # Finally, a valid rule!
+            rule = {
                 "names": syscall["names"],
-                "action": syscall["action"],
-                "args": syscall["args"]
-            })
+                "action": syscall["action"]
+            }
 
-        # Done, append this to the OCI config
+            if syscall.get('args'):
+                rule["args"] = syscall["args"]
+
+            # Some seccomp blocks can return custom errors. Defaults to EPERM if not specified
+            if syscall.get('errnoRet'):
+                rule['errnoRet'] = syscall['errnoRet']
+
+            spec_cfg["syscalls"].append(rule)
+
+        # All rules processed, append this to the OCI config
         logger.info("Created seccomp rules")
         self.oci_config["linux"]["seccomp"] = spec_cfg

--- a/bundlegen/profiles/seccomp/base.json
+++ b/bundlegen/profiles/seccomp/base.json
@@ -1,0 +1,59 @@
+{
+	"defaultAction": "SCMP_ACT_ERRNO",
+	"defaultErrnoRet": 1,
+	"archMap": [
+		{
+			"architecture": "SCMP_ARCH_X86_64",
+			"subArchitectures": [
+				"SCMP_ARCH_X86",
+				"SCMP_ARCH_X32"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_AARCH64",
+			"subArchitectures": [
+				"SCMP_ARCH_ARM"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_MIPS64",
+			"subArchitectures": [
+				"SCMP_ARCH_MIPS",
+				"SCMP_ARCH_MIPS64N32"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_MIPS64N32",
+			"subArchitectures": [
+				"SCMP_ARCH_MIPS",
+				"SCMP_ARCH_MIPS64"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_MIPSEL64",
+			"subArchitectures": [
+				"SCMP_ARCH_MIPSEL",
+				"SCMP_ARCH_MIPSEL64N32"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_MIPSEL64N32",
+			"subArchitectures": [
+				"SCMP_ARCH_MIPSEL",
+				"SCMP_ARCH_MIPSEL64"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_S390X",
+			"subArchitectures": [
+				"SCMP_ARCH_S390"
+			]
+		}
+	],
+	"syscalls": [
+		{
+			"names": [],
+			"action": "SCMP_ACT_ALLOW"
+		}
+	]
+}

--- a/bundlegen/profiles/seccomp/default.json
+++ b/bundlegen/profiles/seccomp/default.json
@@ -1,0 +1,826 @@
+{
+	"defaultAction": "SCMP_ACT_ERRNO",
+	"archMap": [
+		{
+			"architecture": "SCMP_ARCH_X86_64",
+			"subArchitectures": [
+				"SCMP_ARCH_X86",
+				"SCMP_ARCH_X32"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_AARCH64",
+			"subArchitectures": [
+				"SCMP_ARCH_ARM"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_MIPS64",
+			"subArchitectures": [
+				"SCMP_ARCH_MIPS",
+				"SCMP_ARCH_MIPS64N32"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_MIPS64N32",
+			"subArchitectures": [
+				"SCMP_ARCH_MIPS",
+				"SCMP_ARCH_MIPS64"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_MIPSEL64",
+			"subArchitectures": [
+				"SCMP_ARCH_MIPSEL",
+				"SCMP_ARCH_MIPSEL64N32"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_MIPSEL64N32",
+			"subArchitectures": [
+				"SCMP_ARCH_MIPSEL",
+				"SCMP_ARCH_MIPSEL64"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_S390X",
+			"subArchitectures": [
+				"SCMP_ARCH_S390"
+			]
+		}
+	],
+	"syscalls": [
+		{
+			"names": [
+				"accept",
+				"accept4",
+				"access",
+				"adjtimex",
+				"alarm",
+				"bind",
+				"brk",
+				"capget",
+				"capset",
+				"chdir",
+				"chmod",
+				"chown",
+				"chown32",
+				"clock_adjtime",
+				"clock_adjtime64",
+				"clock_getres",
+				"clock_getres_time64",
+				"clock_gettime",
+				"clock_gettime64",
+				"clock_nanosleep",
+				"clock_nanosleep_time64",
+				"close",
+				"close_range",
+				"connect",
+				"copy_file_range",
+				"creat",
+				"dup",
+				"dup2",
+				"dup3",
+				"epoll_create",
+				"epoll_create1",
+				"epoll_ctl",
+				"epoll_ctl_old",
+				"epoll_pwait",
+				"epoll_pwait2",
+				"epoll_wait",
+				"epoll_wait_old",
+				"eventfd",
+				"eventfd2",
+				"execve",
+				"execveat",
+				"exit",
+				"exit_group",
+				"faccessat",
+				"faccessat2",
+				"fadvise64",
+				"fadvise64_64",
+				"fallocate",
+				"fanotify_mark",
+				"fchdir",
+				"fchmod",
+				"fchmodat",
+				"fchown",
+				"fchown32",
+				"fchownat",
+				"fcntl",
+				"fcntl64",
+				"fdatasync",
+				"fgetxattr",
+				"flistxattr",
+				"flock",
+				"fork",
+				"fremovexattr",
+				"fsetxattr",
+				"fstat",
+				"fstat64",
+				"fstatat64",
+				"fstatfs",
+				"fstatfs64",
+				"fsync",
+				"ftruncate",
+				"ftruncate64",
+				"futex",
+				"futex_time64",
+				"futimesat",
+				"getcpu",
+				"getcwd",
+				"getdents",
+				"getdents64",
+				"getegid",
+				"getegid32",
+				"geteuid",
+				"geteuid32",
+				"getgid",
+				"getgid32",
+				"getgroups",
+				"getgroups32",
+				"getitimer",
+				"getpeername",
+				"getpgid",
+				"getpgrp",
+				"getpid",
+				"getppid",
+				"getpriority",
+				"getrandom",
+				"getresgid",
+				"getresgid32",
+				"getresuid",
+				"getresuid32",
+				"getrlimit",
+				"get_robust_list",
+				"getrusage",
+				"getsid",
+				"getsockname",
+				"getsockopt",
+				"get_thread_area",
+				"gettid",
+				"gettimeofday",
+				"getuid",
+				"getuid32",
+				"getxattr",
+				"inotify_add_watch",
+				"inotify_init",
+				"inotify_init1",
+				"inotify_rm_watch",
+				"io_cancel",
+				"ioctl",
+				"io_destroy",
+				"io_getevents",
+				"io_pgetevents",
+				"io_pgetevents_time64",
+				"ioprio_get",
+				"ioprio_set",
+				"io_setup",
+				"io_submit",
+				"io_uring_enter",
+				"io_uring_register",
+				"io_uring_setup",
+				"ipc",
+				"kill",
+				"lchown",
+				"lchown32",
+				"lgetxattr",
+				"link",
+				"linkat",
+				"listen",
+				"listxattr",
+				"llistxattr",
+				"_llseek",
+				"lremovexattr",
+				"lseek",
+				"lsetxattr",
+				"lstat",
+				"lstat64",
+				"madvise",
+				"membarrier",
+				"memfd_create",
+				"mincore",
+				"mkdir",
+				"mkdirat",
+				"mknod",
+				"mknodat",
+				"mlock",
+				"mlock2",
+				"mlockall",
+				"mmap",
+				"mmap2",
+				"mprotect",
+				"mq_getsetattr",
+				"mq_notify",
+				"mq_open",
+				"mq_timedreceive",
+				"mq_timedreceive_time64",
+				"mq_timedsend",
+				"mq_timedsend_time64",
+				"mq_unlink",
+				"mremap",
+				"msgctl",
+				"msgget",
+				"msgrcv",
+				"msgsnd",
+				"msync",
+				"munlock",
+				"munlockall",
+				"munmap",
+				"nanosleep",
+				"newfstatat",
+				"_newselect",
+				"open",
+				"openat",
+				"openat2",
+				"pause",
+				"pidfd_open",
+				"pidfd_send_signal",
+				"pipe",
+				"pipe2",
+				"poll",
+				"ppoll",
+				"ppoll_time64",
+				"prctl",
+				"pread64",
+				"preadv",
+				"preadv2",
+				"prlimit64",
+				"pselect6",
+				"pselect6_time64",
+				"pwrite64",
+				"pwritev",
+				"pwritev2",
+				"read",
+				"readahead",
+				"readlink",
+				"readlinkat",
+				"readv",
+				"recv",
+				"recvfrom",
+				"recvmmsg",
+				"recvmmsg_time64",
+				"recvmsg",
+				"remap_file_pages",
+				"removexattr",
+				"rename",
+				"renameat",
+				"renameat2",
+				"restart_syscall",
+				"rmdir",
+				"rseq",
+				"rt_sigaction",
+				"rt_sigpending",
+				"rt_sigprocmask",
+				"rt_sigqueueinfo",
+				"rt_sigreturn",
+				"rt_sigsuspend",
+				"rt_sigtimedwait",
+				"rt_sigtimedwait_time64",
+				"rt_tgsigqueueinfo",
+				"sched_getaffinity",
+				"sched_getattr",
+				"sched_getparam",
+				"sched_get_priority_max",
+				"sched_get_priority_min",
+				"sched_getscheduler",
+				"sched_rr_get_interval",
+				"sched_rr_get_interval_time64",
+				"sched_setaffinity",
+				"sched_setattr",
+				"sched_setparam",
+				"sched_setscheduler",
+				"sched_yield",
+				"seccomp",
+				"select",
+				"semctl",
+				"semget",
+				"semop",
+				"semtimedop",
+				"semtimedop_time64",
+				"send",
+				"sendfile",
+				"sendfile64",
+				"sendmmsg",
+				"sendmsg",
+				"sendto",
+				"setfsgid",
+				"setfsgid32",
+				"setfsuid",
+				"setfsuid32",
+				"setgid",
+				"setgid32",
+				"setgroups",
+				"setgroups32",
+				"setitimer",
+				"setpgid",
+				"setpriority",
+				"setregid",
+				"setregid32",
+				"setresgid",
+				"setresgid32",
+				"setresuid",
+				"setresuid32",
+				"setreuid",
+				"setreuid32",
+				"setrlimit",
+				"set_robust_list",
+				"setsid",
+				"setsockopt",
+				"set_thread_area",
+				"set_tid_address",
+				"setuid",
+				"setuid32",
+				"setxattr",
+				"shmat",
+				"shmctl",
+				"shmdt",
+				"shmget",
+				"shutdown",
+				"sigaltstack",
+				"signalfd",
+				"signalfd4",
+				"sigprocmask",
+				"sigreturn",
+				"socket",
+				"socketcall",
+				"socketpair",
+				"splice",
+				"stat",
+				"stat64",
+				"statfs",
+				"statfs64",
+				"statx",
+				"symlink",
+				"symlinkat",
+				"sync",
+				"sync_file_range",
+				"syncfs",
+				"sysinfo",
+				"tee",
+				"tgkill",
+				"time",
+				"timer_create",
+				"timer_delete",
+				"timer_getoverrun",
+				"timer_gettime",
+				"timer_gettime64",
+				"timer_settime",
+				"timer_settime64",
+				"timerfd_create",
+				"timerfd_gettime",
+				"timerfd_gettime64",
+				"timerfd_settime",
+				"timerfd_settime64",
+				"times",
+				"tkill",
+				"truncate",
+				"truncate64",
+				"ugetrlimit",
+				"umask",
+				"uname",
+				"unlink",
+				"unlinkat",
+				"utime",
+				"utimensat",
+				"utimensat_time64",
+				"utimes",
+				"vfork",
+				"vmsplice",
+				"wait4",
+				"waitid",
+				"waitpid",
+				"write",
+				"writev"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"ptrace"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": null,
+			"comment": "",
+			"includes": {
+				"minKernel": "4.8"
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"personality"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 0,
+					"op": "SCMP_CMP_EQ"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"personality"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 8,
+					"op": "SCMP_CMP_EQ"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"personality"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 131072,
+					"op": "SCMP_CMP_EQ"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"personality"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 131080,
+					"op": "SCMP_CMP_EQ"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"personality"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 4294967295,
+					"op": "SCMP_CMP_EQ"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"sync_file_range2"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"arches": [
+					"ppc64le"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"arm_fadvise64_64",
+				"arm_sync_file_range",
+				"sync_file_range2",
+				"breakpoint",
+				"cacheflush",
+				"set_tls"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"arches": [
+					"arm",
+					"arm64"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"arch_prctl"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"arches": [
+					"amd64",
+					"x32"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"modify_ldt"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"arches": [
+					"amd64",
+					"x32",
+					"x86"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"s390_pci_mmio_read",
+				"s390_pci_mmio_write",
+				"s390_runtime_instr"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"arches": [
+					"s390",
+					"s390x"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"open_by_handle_at"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_DAC_READ_SEARCH"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"bpf",
+				"clone",
+				"fanotify_init",
+				"fsconfig",
+				"fsmount",
+				"fsopen",
+				"fspick",
+				"lookup_dcookie",
+				"mount",
+				"move_mount",
+				"name_to_handle_at",
+				"open_tree",
+				"perf_event_open",
+				"quotactl",
+				"setdomainname",
+				"sethostname",
+				"setns",
+				"syslog",
+				"umount",
+				"umount2",
+				"unshare"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_ADMIN"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"clone"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 2114060288,
+					"op": "SCMP_CMP_MASKED_EQ"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_ADMIN"
+				],
+				"arches": [
+					"s390",
+					"s390x"
+				]
+			}
+		},
+		{
+			"names": [
+				"clone"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 1,
+					"value": 2114060288,
+					"op": "SCMP_CMP_MASKED_EQ"
+				}
+			],
+			"comment": "s390 parameter ordering for clone is different",
+			"includes": {
+				"arches": [
+					"s390",
+					"s390x"
+				]
+			},
+			"excludes": {
+				"caps": [
+                    "CAP_SYS_ADMIN"
+				]
+			}
+		},
+		{
+			"names": [
+				"reboot"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_BOOT"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"chroot"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_CHROOT"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"delete_module",
+				"init_module",
+				"finit_module"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_MODULE"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"acct"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_PACCT"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"kcmp",
+				"pidfd_getfd",
+				"process_madvise",
+				"process_vm_readv",
+				"process_vm_writev",
+				"ptrace"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_PTRACE"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"iopl",
+				"ioperm"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_RAWIO"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"settimeofday",
+				"stime",
+				"clock_settime"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_TIME"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"vhangup"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_TTY_CONFIG"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"get_mempolicy",
+				"mbind",
+				"set_mempolicy"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_NICE"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"syslog"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYSLOG"
+				]
+			},
+			"excludes": {}
+		}
+	]
+}

--- a/bundlegen/profiles/seccomp/default.json
+++ b/bundlegen/profiles/seccomp/default.json
@@ -1,5 +1,6 @@
 {
 	"defaultAction": "SCMP_ACT_ERRNO",
+	"defaultErrnoRet": 1,
 	"archMap": [
 		{
 			"architecture": "SCMP_ARCH_X86_64",
@@ -393,23 +394,18 @@
 				"write",
 				"writev"
 			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
-			"includes": {},
-			"excludes": {}
+			"action": "SCMP_ACT_ALLOW"
 		},
 		{
 			"names": [
+				"process_vm_readv",
+				"process_vm_writev",
 				"ptrace"
 			],
 			"action": "SCMP_ACT_ALLOW",
-			"args": null,
-			"comment": "",
 			"includes": {
 				"minKernel": "4.8"
-			},
-			"excludes": {}
+			}
 		},
 		{
 			"names": [
@@ -422,10 +418,7 @@
 					"value": 0,
 					"op": "SCMP_CMP_EQ"
 				}
-			],
-			"comment": "",
-			"includes": {},
-			"excludes": {}
+			]
 		},
 		{
 			"names": [
@@ -438,10 +431,7 @@
 					"value": 8,
 					"op": "SCMP_CMP_EQ"
 				}
-			],
-			"comment": "",
-			"includes": {},
-			"excludes": {}
+			]
 		},
 		{
 			"names": [
@@ -454,10 +444,7 @@
 					"value": 131072,
 					"op": "SCMP_CMP_EQ"
 				}
-			],
-			"comment": "",
-			"includes": {},
-			"excludes": {}
+			]
 		},
 		{
 			"names": [
@@ -470,10 +457,7 @@
 					"value": 131080,
 					"op": "SCMP_CMP_EQ"
 				}
-			],
-			"comment": "",
-			"includes": {},
-			"excludes": {}
+			]
 		},
 		{
 			"names": [
@@ -486,24 +470,18 @@
 					"value": 4294967295,
 					"op": "SCMP_CMP_EQ"
 				}
-			],
-			"comment": "",
-			"includes": {},
-			"excludes": {}
+			]
 		},
 		{
 			"names": [
 				"sync_file_range2"
 			],
 			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
 			"includes": {
 				"arches": [
 					"ppc64le"
 				]
-			},
-			"excludes": {}
+			}
 		},
 		{
 			"names": [
@@ -515,46 +493,37 @@
 				"set_tls"
 			],
 			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
 			"includes": {
 				"arches": [
 					"arm",
 					"arm64"
 				]
-			},
-			"excludes": {}
+			}
 		},
 		{
 			"names": [
 				"arch_prctl"
 			],
 			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
 			"includes": {
 				"arches": [
 					"amd64",
 					"x32"
 				]
-			},
-			"excludes": {}
+			}
 		},
 		{
 			"names": [
 				"modify_ldt"
 			],
 			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
 			"includes": {
 				"arches": [
 					"amd64",
 					"x32",
 					"x86"
 				]
-			},
-			"excludes": {}
+			}
 		},
 		{
 			"names": [
@@ -563,34 +532,29 @@
 				"s390_runtime_instr"
 			],
 			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
 			"includes": {
 				"arches": [
 					"s390",
 					"s390x"
 				]
-			},
-			"excludes": {}
+			}
 		},
 		{
 			"names": [
 				"open_by_handle_at"
 			],
 			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
 			"includes": {
 				"caps": [
 					"CAP_DAC_READ_SEARCH"
 				]
-			},
-			"excludes": {}
+			}
 		},
 		{
 			"names": [
 				"bpf",
 				"clone",
+				"clone3",
 				"fanotify_init",
 				"fsconfig",
 				"fsmount",
@@ -612,14 +576,11 @@
 				"unshare"
 			],
 			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
 			"includes": {
 				"caps": [
 					"CAP_SYS_ADMIN"
 				]
-			},
-			"excludes": {}
+			}
 		},
 		{
 			"names": [
@@ -633,8 +594,6 @@
 					"op": "SCMP_CMP_MASKED_EQ"
 				}
 			],
-			"comment": "",
-			"includes": {},
 			"excludes": {
 				"caps": [
 					"CAP_SYS_ADMIN"
@@ -666,7 +625,19 @@
 			},
 			"excludes": {
 				"caps": [
-                    "CAP_SYS_ADMIN"
+					"CAP_SYS_ADMIN"
+				]
+			}
+		},
+		{
+			"names": [
+				"clone3"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"errnoRet": 38,
+			"excludes": {
+				"caps": [
+					"CAP_SYS_ADMIN"
 				]
 			}
 		},
@@ -675,28 +646,22 @@
 				"reboot"
 			],
 			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
 			"includes": {
 				"caps": [
 					"CAP_SYS_BOOT"
 				]
-			},
-			"excludes": {}
+			}
 		},
 		{
 			"names": [
 				"chroot"
 			],
 			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
 			"includes": {
 				"caps": [
 					"CAP_SYS_CHROOT"
 				]
-			},
-			"excludes": {}
+			}
 		},
 		{
 			"names": [
@@ -705,28 +670,22 @@
 				"finit_module"
 			],
 			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
 			"includes": {
 				"caps": [
 					"CAP_SYS_MODULE"
 				]
-			},
-			"excludes": {}
+			}
 		},
 		{
 			"names": [
 				"acct"
 			],
 			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
 			"includes": {
 				"caps": [
 					"CAP_SYS_PACCT"
 				]
-			},
-			"excludes": {}
+			}
 		},
 		{
 			"names": [
@@ -738,14 +697,11 @@
 				"ptrace"
 			],
 			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
 			"includes": {
 				"caps": [
 					"CAP_SYS_PTRACE"
 				]
-			},
-			"excludes": {}
+			}
 		},
 		{
 			"names": [
@@ -753,14 +709,11 @@
 				"ioperm"
 			],
 			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
 			"includes": {
 				"caps": [
 					"CAP_SYS_RAWIO"
 				]
-			},
-			"excludes": {}
+			}
 		},
 		{
 			"names": [
@@ -769,28 +722,22 @@
 				"clock_settime"
 			],
 			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
 			"includes": {
 				"caps": [
 					"CAP_SYS_TIME"
 				]
-			},
-			"excludes": {}
+			}
 		},
 		{
 			"names": [
 				"vhangup"
 			],
 			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
 			"includes": {
 				"caps": [
 					"CAP_SYS_TTY_CONFIG"
 				]
-			},
-			"excludes": {}
+			}
 		},
 		{
 			"names": [
@@ -799,28 +746,22 @@
 				"set_mempolicy"
 			],
 			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
 			"includes": {
 				"caps": [
 					"CAP_SYS_NICE"
 				]
-			},
-			"excludes": {}
+			}
 		},
 		{
 			"names": [
 				"syslog"
 			],
 			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
 			"includes": {
 				"caps": [
 					"CAP_SYSLOG"
 				]
-			},
-			"excludes": {}
+			}
 		}
 	]
 }

--- a/docs/AppMetadata.md
+++ b/docs/AppMetadata.md
@@ -8,7 +8,7 @@ Some application options are defined within the OCI Image, such as the entrypoin
 * `type` (string, REQUIRED). The mime-type of the application. **The exact MIME types are subject to change**. Currently, for native DAC apps, use `application/vnd.rdk-app.dac.native`
 * `graphics` (boolean, REQUIRED). Set to true if the application requires graphics output
 * `network` (object, REQUIRED). Network settings for the application. The object should match the `data` section of the Dobby Networking plugin as defined [here](https://github.com/rdkcentral/Dobby/tree/master/rdkPlugins/Networking/README.md)
-* `storage` (object, REQUIRED). 
+* `storage` (object, REQUIRED).
   * `persistent` (array of objects, REQUIRED). Configure persistent, read/write storage for the application. Each object should have the following options
     * `size` (string, REQUIRED). Amount of storage required
     * `path` (string, REQUIRED). Path where the storage should be mounted inside the container
@@ -19,6 +19,8 @@ Some application options are defined within the OCI Image, such as the entrypoin
   * `ram` (string, REQUIRED). Amount of RAM required by the container
 * `features` (array of strings, OPTIONAL). Any rdkservices/Thunder NanoServices required by the container. If the platform does not support the necessary feature, a bundle cannot be generated
 * `mounts` (array of objects, OPTIONAL). Any additional mounts from the host the container requires. Note that these mounts must exist on the platform, otherwise the container will fail to start. Each object in the array should be an OCI `Mount` object as defined [here](https://github.com/opencontainers/runtime-spec/blob/master/config.md#mounts)
+* `seccomp` (OPTIONAL)
+    * `allow` (array of string, OPTIONAL). Whitelist of allowed syscalls the app can make. When set, any syscalls not in this list will be blocked
 * `priority` (string, OPTIONAL). **Only used for the IPK output format**. Sets the priority value of the IPK. Defaults to `optional` if not set. It's very unlikely you will ever need to set this.
 
 ## Example
@@ -88,6 +90,13 @@ Some application options are defined within the OCI Image, such as the entrypoin
             ]
         }
     ],
-    "priority": "optional"
+    "seccomp": {
+        "allow": [
+            "accept",
+            "chown",
+            "getpid",
+            "mkdir"
+        ]
+    }
 }
 ```

--- a/docs/Templates.md
+++ b/docs/Templates.md
@@ -72,13 +72,16 @@ Platform templates define specific information about a platform that is used whe
     * `devnull` - log to /dev/null (i.e. don't store container logs)
   * `logDir` (string, REQUIRED if `mode` is set to `file`). Directory to store container logs if logging to file
 * `dobby`
-  * `pluginDir` (string, REQUIRED). Location where Dobby plugins are found on the platform. Dobby plugins are by default found in `/usr/lib/plugins/dobby`
-  * `pluginDependencies` (array of strings, REQUIRED. Libraries that the Dobby plugins depend on.
+  * `pluginDir` (string, OPTIONAL). **Only necessary if Dobby explicitly compiled with StartContainer hook support** Location where Dobby plugins are found on the platform. Dobby plugins are by default found in `/usr/lib/plugins/dobby`
+  * `pluginDependencies` (array of strings, OPTIONAL). **Only necessary if Dobby explicitly compiled with StartContainer hook support** Libraries that the Dobby plugins depend on.
     * Dobby plugins are shared objects and have dependencies that must exist in the container. The exact dependencies needed will depend on which plugins are being used on the platform. To find dependencies, run `/lib/ld-linux-armhf.so.3 --list /usr/lib/plugins/dobby/ <plugin-name>` on the platform for each plugin
   * `dobbyInitPath` (string, OPTIONAL). Location where DobbyInit is found on the platform. DobbyInit is by default found in `/usr/libexec/DobbyInit`
   * `generateCompliantConfig` (boolean, OPTIONAL). When set BundleGen will generate the DobbyPluginLauncher hooks (if any plugins are used). This will also set "ociVersion" to "1.0.2" and not "1.0.2-dobby" so that Dobby does not generate these hooks.
   * `hookLauncherExecutablePath` (string, OPTIONAL, only used when generateCompliantConfig is true). Path to the DobbyPluginLauncher binary on the target host. Defaults to "/usr/bin/DobbyPluginLauncher"
   * `hookLauncherParametersPath` (string, REQUIRED if generateCompliantConfig is true). Path in the host that will contain the config.json of the container. It can include the {id} parameter which will be replaced by the id of the app as indicated in the app metadata. For example "/somewhere/{id}"
+* `seccomp` (OPTIONAL)
+  * `enable` (OPTIONAL). Enable/disable seccomp support. Defaults to **enabled** using the default profile provided with BundleGen
+  * `profile` (OPTIONAL). Path to a seccomp profile for the platform. See `profiles/seccomp/default.json` for an example profile.
 * `tarball` (OPTIONAL)
   * `fileOwnershipSameAsUser` (boolean, OPTIONAL). If true then file ownership will be set to match uid/gid of the user that will run inside the container. This uid/gid is set while creating the tarball (inside the tarball only).
   * `fileMask` (string, OPTIONAL). If set, this mask will be applied on the file permissions of every file and dir inside the tarball. This happens while creating the tarball (inside the tarball only). This mask string will be parsed as an octal number. For example "770" will remove all 'rwx' rights for 'other' users.

--- a/sample_app_metadata/helloworld.json
+++ b/sample_app_metadata/helloworld.json
@@ -27,5 +27,11 @@
         "ram": "5M"
     },
     "features": [],
-    "mounts": []
+    "mounts": [],
+    "seccomp": {
+        "allow": [
+            "chown",
+            "getpid"
+        ]
+    }
 }

--- a/templates/generic/rpi3_reference.json
+++ b/templates/generic/rpi3_reference.json
@@ -1,6 +1,7 @@
 {
     "platformName": "rpi3_reference",
     "os": "linux",
+    "kernel": "4.4.0-201-generic",
     "arch": {
         "arch": "arm",
         "variant": "v7"

--- a/templates/generic/vagrant.json
+++ b/templates/generic/vagrant.json
@@ -1,6 +1,7 @@
 {
     "platformName": "vagrant",
     "os": "linux",
+    "kernel": "4.4.0-201-generic",
     "arch": {
         "arch": "amd64"
     },


### PR DESCRIPTION
**WIP: DO NOT MERGE**

Add a default seccomp profile based on the Docker implementation documented here: https://docs.docker.com/engine/security/seccomp/, which has a good balance of security/compatibility. 

Requires a `kernel` property in the platform template