### PR TITLE
Use by default libraries from image

### DIFF
--- a/test/build_and_test_on_rpi.sh
+++ b/test/build_and_test_on_rpi.sh
@@ -26,6 +26,6 @@ tar -xvf $OCI_TAR -C ./oci-${APP_NAME}
 
 echo "--> Generating runtime bundle..."
 rm -rf ./rpi-${APP_NAME}
-bundlegen -vvv generate --searchpath templates --platform rpi3_reference oci:./oci-${APP_NAME}:latest rpi-${APP_NAME}
+bundlegen -vvv generate --searchpath templates --platform rpi3_reference -m image oci:./oci-${APP_NAME}:latest rpi-${APP_NAME}
 
 ./test/testapp.sh $BOXIP rpi-${APP_NAME}.tar.gz


### PR DESCRIPTION
This seems to be mandatory especially when
the image was generated using Yocto 3.1 and then
deployed on the platform powered by Yocto 2.2.

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>