### PR TITLE
Allow tools skopeo and umoci to be found on custom path

### DIFF
--- a/bundlegen/cli/main.py
+++ b/bundlegen/cli/main.py
@@ -96,7 +96,7 @@ def generate(image, outputdir, platform, searchpath, creds, ipk, appmetadata, ye
         return
 
     # Download the image to a temp directory
-    img_downloader = ImageDownloader()
+    img_downloader = ImageDownloader(tool=os.environ.get('SKOPEO_TOOL_PATH'))
     img_path = img_downloader.download_image(
         image, creds, selected_platform.get_config())
 
@@ -104,8 +104,8 @@ def generate(image, outputdir, platform, searchpath, creds, ipk, appmetadata, ye
         return
 
     # Unpack the image with umoci
-    tag = ImageDownloader().get_image_tag(image)
-    img_unpacker = ImageUnpackager(src=img_path, dst=outputdir)
+    tag = img_downloader.get_image_tag(image)
+    img_unpacker = ImageUnpackager(src=img_path, dst=outputdir, tool=os.environ.get('UMOCI_TOOL_PATH'))
     unpack_success = img_unpacker.unpack_image(tag, delete=True)
 
     if not unpack_success:

--- a/bundlegen/core/image_downloader.py
+++ b/bundlegen/core/image_downloader.py
@@ -23,11 +23,12 @@ from bundlegen.core.utils import Utils
 
 
 class ImageDownloader():
-    def __init__(self):
+    def __init__(self, tool):
         # Optimism
         self.skopeo_found = True
-
-        if os.path.isfile('/usr/bin/skopeo'):
+        if tool and os.path.isfile(tool):
+            self.skopeo_path = tool
+        elif os.path.isfile('/usr/bin/skopeo'):
             self.skopeo_path = '/usr/bin/skopeo'
         elif os.path.isfile('/bin/skopeo'):
             self.skopeo_path = '/bin/skopeo'

--- a/bundlegen/core/image_unpacker.py
+++ b/bundlegen/core/image_unpacker.py
@@ -23,11 +23,12 @@ from bundlegen.core.utils import Utils
 
 
 class ImageUnpackager():
-    def __init__(self, src, dst):
+    def __init__(self, src, dst, tool):
         # Optimism
         self.umoci_found = True
-
-        if os.path.isfile('/usr/bin/umoci'):
+        if tool and os.path.isfile(tool):
+            self.umoci_path = tool
+        elif os.path.isfile('/usr/bin/umoci'):
             self.umoci_path = '/usr/bin/umoci'
         elif os.path.isfile('/usr/local/bin/umoci'):
             self.umoci_path = '/usr/local/bin/umoci'


### PR DESCRIPTION
* use env var SKOPEO_TOOL_PATH and UMOCI_TOOL_PATH
* usefull when using bundlgen in yocto build env where
  skopeo and umoci are also built and provided in sysroot