### PR TITLE
Set skopeo --insecure-policy flag

### DIFF
--- a/bundlegen/core/image_downloader.py
+++ b/bundlegen/core/image_downloader.py
@@ -100,7 +100,7 @@ class ImageDownloader():
         logger.info(f"Downloading image to {destination}...")
 
         # Build the command to skopeo
-        skopeo_command = f'skopeo '
+        skopeo_command = f'skopeo --insecure-policy '
 
         if creds:
             skopeo_command += f'--src-creds {creds} '

--- a/bundlegen/core/image_downloader.py
+++ b/bundlegen/core/image_downloader.py
@@ -100,7 +100,14 @@ class ImageDownloader():
         logger.info(f"Downloading image to {destination}...")
 
         # Build the command to skopeo
-        skopeo_command = f'skopeo --insecure-policy '
+        skopeo_command = f'skopeo '
+
+        if (os.path.exists(os.path.expanduser('~/.config/containers/policy.json')) or
+           os.path.exists('/etc/containers/policy.json')):
+           logger.debug('Found a policy.json file for skopeo')
+        else:
+           logger.debug('Did not find a policy.json file for skopeo. Will use insecure-policy flag for skopeo!')
+           skopeo_command += '--insecure-policy '
 
         if creds:
             skopeo_command += f'--src-creds {creds} '


### PR DESCRIPTION
* this avoids skopeo wanting to read /etc/containers/policy.json
  which is not there when building and using skopeo from inside yocto
  build env

  https://github.com/containers/skopeo/blob/main/docs/skopeo.1.md