### PR TITLE
Several updates to storages

### DIFF
--- a/bundlegen/core/bundle_processor.py
+++ b/bundlegen/core/bundle_processor.py
@@ -511,10 +511,22 @@ class BundleProcessor:
                     # Validate we are allowed a size this large
                     maxSize = self.platform_cfg.get(
                         'storage').get('persistent').get('maxSize')
+                    minSize = self.platform_cfg.get(
+                        'storage').get('persistent').get('minSize')
+                    fstype = self.platform_cfg.get(
+                        'storage').get('persistent').get('fstype')
+                    if fstype is None:
+                        fstype = "ext4"
 
-                    if maxSize and humanfriendly.parse_size(size) > humanfriendly.parse_size(maxSize):
+                    if maxSize and humanfriendly.parse_size(size, binary=True) > humanfriendly.parse_size(maxSize, binary=True):
                         logger.warning(
-                            f"Persistent storage requested by app exceeds platform limit ({size} > {maxSize}")
+                            f"Persistent storage requested by app exceeds platform limit ({size} > {maxSize})")
+
+                    if minSize and humanfriendly.parse_size(size, binary=True) < humanfriendly.parse_size(minSize, binary=True):
+                        logger.warning(
+                            f"Persistent storage requested by app is less than minimum required by platform ({size} < {minSize})")
+                        logger.warning(f"Auto adjusting to {minSize} !")
+                        size = minSize
 
                     if not self.platform_cfg.get('storage').get('persistent'):
                         logger.error(
@@ -531,9 +543,9 @@ class BundleProcessor:
                     loopback_mnt_def = {
                         "destination": dest_path,
                         "flags": 14,
-                        "fstype": "ext4",
+                        "fstype": f"{fstype}",
                         "source": source_path,
-                        "imgsize": humanfriendly.parse_size(size)
+                        "imgsize": humanfriendly.parse_size(size, binary=True)
                     }
 
                     loopback_plugin['data']['loopback'].append(
@@ -551,14 +563,22 @@ class BundleProcessor:
             # Temp storage just uses a normal OCI mount set to tmpfs with the
             # size set accordingly
             if storage_settings.get('temp'):
-                for tmp_mnnt in storage_settings.get('temp'):
-                    size = humanfriendly.parse_size(tmp_mnnt.get('size'))
+                user = self.oci_config['process'].get('user')
+                uid = user.get('uid') if user else None
+                gid = user.get('gid') if user else None
 
+                for tmp_mnnt in storage_settings.get('temp'):
+                    size = humanfriendly.parse_size(tmp_mnnt.get('size'), binary=True)
+                    options = ["nosuid", "strictatime", f"mode=755", f"size={size}"]
+                    if uid:
+                        options.append(f"uid={uid}")
+                    if gid:
+                        options.append(f"gid={gid}")
                     mnt_to_add = {
                         "destination": tmp_mnnt['path'],
                         "type": "tmpfs",
                         "source": "tmpfs",
-                        "options": ["nosuid", "strictatime", "mode=755", f"size={size}"]
+                        "options": options
                     }
 
                     self.oci_config['mounts'].append(mnt_to_add)

--- a/docs/Templates.md
+++ b/docs/Templates.md
@@ -27,6 +27,8 @@ Platform templates define specific information about a platform that is used whe
   * `persistent` (object, OPTIONAL) Dobby supports persistent storage using loopback mounts. If the platform should not support loopback mounts, do not define this section
     * `storageDir` (string, REQUIRED). Where to store the `img` files that are mounted into the container
     * `maxSize` (string, REQUIRED). Maximum allowed size of the image files
+    * `minSize` (string, OPTIONAL). Minimum required size of the image files. Some filesystem types need a minimum size. When set, the size of a storage will be auto increased to match this minium. This is logged as a warning.
+    * `fstype` (string, OPTIONAL). Filesystem type to use like ext4 or xfs. Defaults to ext4.
 * `gpu`
   * `westeros` (object, OPTIONAL). If the platform uses a hard-coded path to a westeros socket, then set it here. If RDKShell is used to create displays, then a westeros socket path can be provided to Dobby dynamically when starting the container and this option can be excluded
     * `hostSocket` (string, OPTIONAL). Path to the hard-coded westeros socket on the host


### PR DESCRIPTION
* add process.user uid/gid to options of tmpfs temp storages
* allow fstype to be specified for persistent storages
* also support a minSize for persistent storages
  (we experienced mk.xfs problem with sizes < 16MB)
  Auto increment to match minSize and log warning.
* parse all (storage) sizes with option binary=True so that
  1 MB really is 1MByte and not 1000000 bytes