### PR TITLE
Support to set rootfs path and readonly property

### DIFF
--- a/bundlegen/core/bundle_processor.py
+++ b/bundlegen/core/bundle_processor.py
@@ -63,6 +63,7 @@ class BundleProcessor:
             self._create_mount_points_umoci()
         self._process_oci_version()
         self._process_process()
+        self._process_root()
         self._process_mounts()
         self._process_resources()
         self._process_gpu()
@@ -222,6 +223,23 @@ class BundleProcessor:
         if resource_limits:
             for limit in resource_limits:
                 self.oci_config['process']['rlimits'].append(limit)
+
+    # ==========================================================================
+    def _process_root(self):
+        logger.debug("Processing root section")
+
+        root = self.platform_cfg.get('root')
+        if not root:
+            return
+
+        readonly = root.get('readonly')
+        if readonly:
+            self.oci_config['root']['readonly'] = readonly
+
+        path = root.get('path')
+        if path:
+            path = path.format(id = self.app_metadata['id'])
+            self.oci_config['root']['path'] = path
 
     # ==========================================================================
     def _process_mounts(self):

--- a/docs/Templates.md
+++ b/docs/Templates.md
@@ -40,6 +40,9 @@ Platform templates define specific information about a platform that is used whe
       * `src` (string, REQUIRED). Path to the library on the host
       * `dst` (string, REQUIRED). Mount destination inside the container
   * `waylandDisplay` (string, OPTIONAL). Wayland compositor, by default set to 'westeros'.
+* `root` (OPTIONAL)
+  * `path` (string, OPTIONAL). If set override the default rootfs path. In addition this path can include the {id} parameter which will be replaced by the id of the app as indicated in the app metadata. This allows BundleGen to generate the full rootfs path as it will exist on the target platform. For example: /somewhere/run/rootfs/{id}
+  * `readonly` (boolean, OPTIONAL). Set to true to mark the rootfs readonly.
 * `mounts` (array of mount objects, OPTIONAL). Any extra mounts that should be added to the config. Can be left empty if no mounts needed. Each item in the array should be an OCI `Mount` object as defined [here](https://github.com/opencontainers/runtime-spec/blob/master/config.md#mounts)
 * `network` (array of string, REQUIRED). Which network modes the platform supports and an application could use. Dobby's Networking plugin offers `nat`, `private` and `open` network options by default.
 * `envvar` (array of string, OPTIONAL). Any additional environment variables that should be set on all containers running on the platform


### PR DESCRIPTION
* this path can include the {id} parameter which will be replaced by the id
  of the app as indicated in the app metadata.
  This allows BundleGen to generate the full rootfs path as it will exist on
  the target platform. For example: /somewhere/run/rootfs/{id}