### PR TITLE
Support hostname

### DIFF
--- a/bundlegen/core/bundle_processor.py
+++ b/bundlegen/core/bundle_processor.py
@@ -70,6 +70,7 @@ class BundleProcessor:
         self._process_dobby_plugin_dependencies()
         self._process_users_and_groups()
         self._process_capabilities()
+        self._process_hostname()
 
         # RDK Plugins section
         self._add_rdk_plugins()
@@ -240,6 +241,15 @@ class BundleProcessor:
         if path:
             path = path.format(id = self.app_metadata['id'])
             self.oci_config['root']['path'] = path
+
+    # ==========================================================================
+    def _process_hostname(self):
+        logger.debug("Processing hostname section")
+
+        hostname = self.platform_cfg.get('hostname')
+        if hostname:
+            hostname = hostname.format(id = self.app_metadata['id'])
+            self.oci_config['hostname'] = hostname
 
     # ==========================================================================
     def _process_mounts(self):

--- a/docs/Templates.md
+++ b/docs/Templates.md
@@ -45,6 +45,7 @@ Platform templates define specific information about a platform that is used whe
 * `root` (OPTIONAL)
   * `path` (string, OPTIONAL). If set override the default rootfs path. In addition this path can include the {id} parameter which will be replaced by the id of the app as indicated in the app metadata. This allows BundleGen to generate the full rootfs path as it will exist on the target platform. For example: /somewhere/run/rootfs/{id}
   * `readonly` (boolean, OPTIONAL). Set to true to mark the rootfs readonly.
+* `hostname` (string, OPTIONAL). If set, override the default hostname. In addition this hostname can include the {id} parameter which will be replaced by the id of the app as indicated in the app metadata.
 * `mounts` (array of mount objects, OPTIONAL). Any extra mounts that should be added to the config. Can be left empty if no mounts needed. Each item in the array should be an OCI `Mount` object as defined [here](https://github.com/opencontainers/runtime-spec/blob/master/config.md#mounts)
 * `network` (array of string, REQUIRED). Which network modes the platform supports and an application could use. Dobby's Networking plugin offers `nat`, `private` and `open` network options by default.
 * `envvar` (array of string, OPTIONAL). Any additional environment variables that should be set on all containers running on the platform


### PR DESCRIPTION
 * Optional. If set, override the default hostname. In addition this hostname can
   include the {id} parameter which will be replaced by the id of the app as
   indicated in the app metadata.