### PR TITLE
Support stdout/stderr logging annotations and terminal

### DIFF
--- a/bundlegen/core/bundle_processor.py
+++ b/bundlegen/core/bundle_processor.py
@@ -650,6 +650,12 @@ class BundleProcessor:
                     self._createEmptyDirInRootfs(tmp_mnnt['path'])
 
     # ==========================================================================
+    def _add_annotation(self, key, value):
+        """Adds an annotation to the config
+        """
+        self.oci_config['annotations'][key] = value
+
+    # ==========================================================================
     def _process_logging(self):
         """Adds the logging plugin to the config to set up container logs
         """
@@ -660,6 +666,7 @@ class BundleProcessor:
                 "Platform does not contain logging options - container will not produce any logs")
             return
 
+        self.oci_config['process']['terminal'] = True
         logging_plugin = {}
 
         # If logging to a file
@@ -676,11 +683,13 @@ class BundleProcessor:
                     }
                 }
             }
+            self._add_annotation('run.oci.hooks.stderr','/dev/stderr')
+            self._add_annotation('run.oci.hooks.stdout','/dev/stdout')
         elif self.platform_cfg['logging'].get('mode') == 'journald':
             logging_plugin = {
                 "required": True,
                 "data": {
-                    "sink": "jourald"
+                    "sink": "journald"
                 }
             }
 


### PR DESCRIPTION
* also support terminal setting to explicitly enable or
  disable a terminal
* also fix typo in journald log mode
* Dobby normally auto generates this when starting and when logging is enabled. But this change is one of several that helps with a read-only config.json