### PR TITLE
ONEM-25427 add app_id override for BundleGen

### DIFF
--- a/bundlegen/rabbitmq/README.md
+++ b/bundlegen/rabbitmq/README.md
@@ -31,7 +31,13 @@ output_filename: str,
 searchpath: str,
 outputdir: str,
 createmountpoints: bool,
+app_id: str,
 ```
+*app_metadata:*
+Optional. If not empty, this metadata will override all the metadata present inside the OCI image. If no metadata present inside the OCI image, then this parameter is mandatory.
+
+*app_id:*
+Optional. If not empty, used to override the id inside the metadata. Mainly intended for override on app id inside the metadata inside the OCI image.
 
 BundleGen will respond with the following message on success/failure
 ```

--- a/bundlegen/rabbitmq/message.py
+++ b/bundlegen/rabbitmq/message.py
@@ -42,7 +42,8 @@ class Message():
                  output_filename: str,
                  searchpath: str,
                  outputdir: str,
-                 createmountpoints: bool):
+                 createmountpoints: bool,
+                 app_id: str):
         self.uuid = uuid
         self.platform = platform
         self.image_url = image_url
@@ -50,6 +51,7 @@ class Message():
         self.searchpath = searchpath
         self.outputdir = outputdir
         self.createmountpoints = createmountpoints
+        self.app_id = app_id
 
         if app_metadata is None:
             self.app_metadata = {}

--- a/bundlegen/rabbitmq/message_handler.py
+++ b/bundlegen/rabbitmq/message_handler.py
@@ -45,7 +45,8 @@ def message_decoder(obj):
                           unpacked_obj["output_filename"],
                           unpacked_obj["searchpath"],
                           unpacked_obj["outputdir"],
-                          unpacked_obj["createmountpoints"])
+                          unpacked_obj["createmountpoints"],
+                          unpacked_obj["app_id"])
     return msg
 
 
@@ -176,6 +177,8 @@ def generate_bundle(options: message.Message) -> Tuple[Result, str]:
         app_metadata_dict = metadata_from_image
         img_unpacker.delete_img_app_metadata()
 
+    if options.app_id:
+        app_metadata_dict['id'] = options.app_id
 
     # Begin processing. Work in the output dir where the img was unpacked to
     processor = BundleProcessor(

--- a/bundlegen/rabbitmq/test/test.py
+++ b/bundlegen/rabbitmq/test/test.py
@@ -88,7 +88,7 @@ def main():
 
     msg = message.Message(uuid_str, "rpi3_reference",
                           "docker://hello-world", metadata, message.LibMatchMode.NORMAL,
-                          "","", "", True)
+                          "","", "", True, "")
 
     logger.debug(f"Request: \n{pprint.pformat(msg.__dict__)}")
     logger.info("Sending request to BundleGen")


### PR DESCRIPTION
* add app_id to rabbitmq message so that we can override
  the id inside the metadata. Handy when metadata is inside OCI
  image and we only want to override the id.