### PR TITLE
RDKCMF-8834 support latest rialto

### DIFF
--- a/templates/generic/rpi3_reference_dunfell.json
+++ b/templates/generic/rpi3_reference_dunfell.json
@@ -87,8 +87,8 @@
                 ]
             },
             {
-                "source": "/var/run/dbus/system_bus_socket",
-                "destination": "/var/run/dbus/system_bus_socket",
+                "source": "/tmp/rialto-0",
+                "destination": "/tmp/rialto-0",
                 "type": "bind",
                 "options": [
                     "bind",
@@ -97,8 +97,7 @@
             }
         ],
         "envvar": [
-            "LD_PRELOAD=/usr/lib/libGLESv2.so.2:/usr/lib/libwayland-egl.so.1",
-            "RIALTO_CLIENT_BACKEND_LIB=/usr/lib/libRialtoClient.so.0.1.0"
+            "LD_PRELOAD=/usr/lib/libGLESv2.so.2:/usr/lib/libwayland-egl.so.1"
         ],
         "devs": [
             {

--- a/templates/lgi/7218c_reference_dunfell.json
+++ b/templates/lgi/7218c_reference_dunfell.json
@@ -95,8 +95,8 @@
                 ]
             },
             {
-                "source": "/var/run/dbus/system_bus_socket",
-                "destination": "/var/run/dbus/system_bus_socket",
+                "source": "/tmp/rialto-0",
+                "destination": "/tmp/rialto-0",
                 "type": "bind",
                 "options": [
                     "bind",
@@ -105,7 +105,7 @@
             }
         ],
         "envvar": [
-            "LD_PRELOAD=/usr/lib/libwayland-client.so.0:/usr/lib/libwayland-egl.so.0", "RIALTO_CLIENT_BACKEND_LIB=/usr/lib/libRialtoClient.so.0.1.0"
+            "LD_PRELOAD=/usr/lib/libwayland-client.so.0:/usr/lib/libwayland-egl.so.0"
         ],
         "devs": [
             {


### PR DESCRIPTION
* use protobuf IPC instead of dbus
* RIALTO_CLIENT_BACKEND_LIB not needed anymore
  (rialto gst sink now links directly to rialtoclient)