### PR TITLE
Fix persistent storage for dac apps on reference image

### DIFF
--- a/bundlegen/cli/main.py
+++ b/bundlegen/cli/main.py
@@ -70,8 +70,9 @@ def cli(verbose):
                                   host: always take host lib and create mount bind. Skips the library from OCI image rootfs if it was there.\n
                                   Default mode is 'normal'. When apiversion info not available the effect is the same as mode 'host'""")
 @click.option('-r', '--createmountpoints', required=False, help='Create mount points in rootfs. Main usage for platforms with RO filesystem.', is_flag=True)
+@click.option('-x', '--appid', required=False, help='Optional. Application id. Can be used to override the id inside the metadata.')
 # @click.option('--disable-lib-mounts', required=False, help='Disable automatically bind mounting in libraries that exist on the STB. May increase bundle size', is_flag=True)
-def generate(image, outputdir, platform, searchpath, creds, ipk, appmetadata, yes, nodepwalking, libmatchingmode, createmountpoints):
+def generate(image, outputdir, platform, searchpath, creds, ipk, appmetadata, yes, nodepwalking, libmatchingmode, createmountpoints, appid):
     """Generate an OCI Bundle for a specified platform
     """
 
@@ -144,6 +145,9 @@ def generate(image, outputdir, platform, searchpath, creds, ipk, appmetadata, ye
         # Take metadata from image
         app_metadata_dict = metadata_from_image
         img_unpacker.delete_img_app_metadata()
+
+    if appid:
+         app_metadata_dict['id'] = appid
 
     # Begin processing. Work in the output dir where the img was unpacked to
     processor = BundleProcessor(

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -102,5 +102,8 @@ Options:
                                   create mount points by crun during container
                                   creation.
 
+  -x, --appid TEXT                Optional. Application id. Can be used to
+                                  override the id inside the metadata.
+
   --help                  Show this message and exit.
 ```

--- a/templates/generic/rpi3_reference_dunfell.json
+++ b/templates/generic/rpi3_reference_dunfell.json
@@ -44,7 +44,7 @@
     },
     "storage": {
         "persistent": {
-            "storageDir": "/opt/data",
+            "storageDir": "/opt/dac_apps/data/0/dac",
             "maxSize": "100M"
         }
     },

--- a/templates/lgi/7218c_reference_dunfell.json
+++ b/templates/lgi/7218c_reference_dunfell.json
@@ -43,7 +43,7 @@
     },
     "storage": {
         "persistent": {
-            "storageDir": "/tmp/data",
+            "storageDir": "/opt/dac_apps/data/0/dac",
             "maxSize": "100M"
         }
     },

--- a/test/build_and_test.sh
+++ b/test/build_and_test.sh
@@ -49,7 +49,7 @@ if [[ $2 == docker://** ]]; then
   echo "--> Generating runtime bundle..."
   rm -rf ./${TEMPLATE}-${APP_NAME}
   ## you might need to login first like: skopeo login us.icr.io
-  bundlegen -vvv generate ${EXTRA_OPTIONS} --searchpath templates --platform ${TEMPLATE} $2 ${TEMPLATE}-${APP_NAME} ${APPMETADATA}
+  bundlegen -vvv generate ${EXTRA_OPTIONS} --appid ${TEMPLATE}-${APP_NAME} --searchpath templates --platform ${TEMPLATE} $2 ${TEMPLATE}-${APP_NAME} ${APPMETADATA}
 else
 
   OCI_TAR=$2
@@ -69,7 +69,7 @@ else
 
   echo "--> Generating runtime bundle..."
   rm -rf ./${TEMPLATE}-${APP_NAME}
-  bundlegen -vvv generate ${EXTRA_OPTIONS} --searchpath templates --platform ${TEMPLATE} oci:./oci-${APP_NAME}:latest ${TEMPLATE}-${APP_NAME} ${APPMETADATA}
+  bundlegen -vvv generate ${EXTRA_OPTIONS} --appid ${TEMPLATE}-${APP_NAME} --searchpath templates --platform ${TEMPLATE} oci:./oci-${APP_NAME}:latest ${TEMPLATE}-${APP_NAME} ${APPMETADATA}
 fi
 
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
* set storage path conforming to LISA data path installation
* support overriding app id through --appid cmdline arg
  (similar as with https://github.com/rdkcentral/BundleGen/commit/a1682e250f1809d274555b55183b3f5f60f662fa)
* update test scripts for this