### PR TITLE
When creating tarball, use real uid/gid if running in user namespace

### DIFF
--- a/bundlegen/cli/main.py
+++ b/bundlegen/cli/main.py
@@ -171,9 +171,10 @@ def generate(image, outputdir, platform, searchpath, creds, ipk, appmetadata, ye
         file_ownership_user = tarball_settings.get('fileOwnershipSameAsUser') if tarball_settings else None
         file_mask = tarball_settings.get('fileMask') if tarball_settings else None
 
-        user = processor.oci_config['process'].get('user')
-        uid = user.get('uid') if user and file_ownership_user else None
-        gid = user.get('gid') if user and file_ownership_user else None
+        container_uid_gid = processor.get_real_uid_gid()
+
+        uid = container_uid_gid[0] if container_uid_gid[0] and file_ownership_user else None
+        gid = container_uid_gid[1] if container_uid_gid[1] and file_ownership_user else None
 
         Utils.create_tgz(outputdir, outputdir, uid, gid, file_mask)
         logger.success(f"Successfully generated bundle at {outputdir}.tar.gz")

--- a/bundlegen/rabbitmq/message_handler.py
+++ b/bundlegen/rabbitmq/message_handler.py
@@ -217,9 +217,9 @@ def generate_bundle(options: message.Message) -> Tuple[Result, str]:
     file_ownership_user = tarball_settings.get('fileOwnershipSameAsUser') if tarball_settings else None
     file_mask = tarball_settings.get('fileMask') if tarball_settings else None
 
-    user = processor.oci_config['process'].get('user')
-    uid = user.get('uid') if user and file_ownership_user else None
-    gid = user.get('gid') if user and file_ownership_user else None
+    container_uid_gid = processor.get_real_uid_gid()
+    uid = container_uid_gid[0] if container_uid_gid[0] and file_ownership_user else None
+    gid = container_uid_gid[1] if container_uid_gid[1] and file_ownership_user else None
 
     Utils.create_tgz(outputdir, tmp_path, uid, gid, file_mask)
 


### PR DESCRIPTION
If the container is configured to run with user namespacing, resolve the real uid/gid when creating the tarball so permissions are set correctly.