### PR TITLE
[RDK-35838] Add Seccomp support to BundleGen

### DIFF
--- a/bundlegen/core/bundle_processor.py
+++ b/bundlegen/core/bundle_processor.py
@@ -72,6 +72,7 @@ class BundleProcessor:
         self._process_users_and_groups()
         self._process_capabilities()
         self._process_hostname()
+        self._process_seccomp()
 
         # RDK Plugins section
         self._add_rdk_plugins()
@@ -991,3 +992,16 @@ class BundleProcessor:
         # Create the directory if doesn't exist
         if not os.path.exists(fullPath):
             os.makedirs(fullPath, 0o755)
+    
+    # ==========================================================================
+    def _process_seccomp(self):
+        """
+        Adds the seccomp information from platform to the config json.
+        """
+        logger.debug(" _process_seccomp ENTER")
+
+        if not self.platform_cfg.get('seccomp'):
+            logger.success(f"Platform does not have seccomp set")
+            return
+        self.oci_config['linux']['seccomp'] = {}
+        self.oci_config['linux']['seccomp'] = self.platform_cfg.get('seccomp')


### PR DESCRIPTION
Activities to be done for adding seccomp support -
1. Add the seccomp field in the respective platform JSON file. This activity is pending since this information needs to be provided by Comcast/platform team.
2. Make changes in bundlegen to copy the info from platform JSON to 'linux' section of the final config JSON. This commit contains changes done for this task only