### PR TITLE
[RDK-35839] Add Apparmor support to BundleGen

### DIFF
--- a/bundlegen/core/bundle_processor.py
+++ b/bundlegen/core/bundle_processor.py
@@ -72,6 +72,7 @@ class BundleProcessor:
         self._process_users_and_groups()
         self._process_capabilities()
         self._process_hostname()
+        self._process_apparmorProfile()
 
         # RDK Plugins section
         self._add_rdk_plugins()
@@ -991,3 +992,15 @@ class BundleProcessor:
         # Create the directory if doesn't exist
         if not os.path.exists(fullPath):
             os.makedirs(fullPath, 0o755)
+    
+    # ==========================================================================
+    def _process_apparmorProfile(self):
+        """"
+        Adds the app armor profile from the platform config if exists to the final config JSON
+        """
+        logger.debug("_process_apparmor ENTER")
+        if not self.platform_cfg.get('apparmorProfile'):
+            logger.info("Platform does not have apparmor profile set")
+            return
+        self.oci_config['process']['apparmorProfile'] = {}
+        self.oci_config['process']['apparmorProfile'] = self.platform_cfg.get('apparmorProfile')


### PR DESCRIPTION
Activities to be done as a part of the above task -
1. Add an apparmor profile in the platform JSON file. This activity is pending since this information needs to be provided by Comcast/platform team.
2. Make changes in bundlegen to copy the apparmor profile name in the 'process' of the final config JSON during OCI bundle creation. This commit contains the changes for this task only.