### PR TITLE
L1 test failing for the latest changes of bundleprocessor.py file

### DIFF
--- a/unit_tests/L1_testing/test_files/test_Bundleprocessor_ut.py
+++ b/unit_tests/L1_testing/test_files/test_Bundleprocessor_ut.py
@@ -379,6 +379,7 @@ class TestBundleProcessor(unittest.TestCase):
         processor.rootfs_path = None
         processor.createmountpoints = None
         processor.app_metadata={
+            "id": "com.rdk.netflix",
             "mounts": [
             {
             "destination": "/data",
@@ -419,6 +420,7 @@ class TestBundleProcessor(unittest.TestCase):
         processor.rootfs_path = None
         processor.createmountpoints = None
         processor.app_metadata={
+            "id": "com.rdk.netflix"
         }
         processor.platform_cfg = {
          "mounts": [
@@ -2581,6 +2583,7 @@ class TestBundleProcessor(unittest.TestCase):
         processor.bundle_path = "/tmp/test"
         processor.createmountpoints = False
         processor.app_metadata = {
+            "id": "com.rdk.netflix",
             "graphics":True
         }
         processor.platform_cfg = {


### PR DESCRIPTION
The L1_tests started failing because of the recent changes in bundle_processor.py by
PR: https://github.com/rdkcentral/BundleGen/pull/97
In PR they are replacing {id} inside mount.source binds with the appid from metadata and placed into separate function _add_mount.
In test code, because of the above update {id} was missing so added the {id} to support that in metadata.