### PR TITLE
Fix issues with rabbitmq, webui and Docker samples

### DIFF
--- a/bundlegen/rabbitmq/message_handler.py
+++ b/bundlegen/rabbitmq/message_handler.py
@@ -188,6 +188,7 @@ def generate_bundle(options: message.Message) -> Tuple[Result, str]:
         False,
         options.lib_match_mode.value,
         options.createmountpoints,
+        False
     )
 
     if not processor.check_compatibility():

--- a/docker/cli-sample/Dockerfile
+++ b/docker/cli-sample/Dockerfile
@@ -31,6 +31,6 @@ RUN git clone https://github.com/rdkcentral/BundleGen.git && \
     sudo pip3 install --editable .
 
 
-WORKDIR /home/bundlegenuser/bundlegen
+WORKDIR /home/bundlegenuser/BundleGen
 
 ENTRYPOINT [ "bundlegen" ]

--- a/docker/rabbitmq/docker-compose.yml
+++ b/docker/rabbitmq/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     environment:
         - BUNDLE_STORE_DIR=/bundles
         - RABBITMQ_HOST=bundlegen-rabbit
+        - BUNDLEGEN_TMP_DIR=/tmp/bundlegen
         - TMP_DIR=/tmp/
     volumes:
         - generated_bundles:/bundles

--- a/webui/app.py
+++ b/webui/app.py
@@ -247,7 +247,7 @@ def index():
 
         # Begin processing. Work in the output dir where the img was unpacked to
         processor = BundleProcessor(
-            selected_platform.get_config(), outputdir, app_metadata_dict, False, form.lib_match.data)
+            selected_platform.get_config(), outputdir, app_metadata_dict, False, form.lib_match.data, False, False)
         if not processor.check_compatibility():
             # Not compatible - delete any work done so far
             shutil.rmtree(outputdir)


### PR DESCRIPTION
* after this change both rabbitmq and webui are broken: LCM-538: Provide option generating raw crun bundle https://github.com/rdkcentral/BundleGen/commit/d8e95111dd23351d8a45385fc2e5fbaab8a9ea6f
* Docker cli sample has wrong WORKDIR (case sensitive) Problem seems to happen after the new schema validation feature was added (loading schema files on dirs with bad case does not work under linux)
* added a missing env var to the rabbitmq docker-compose.yml