### PR TITLE
Update brcm972180hbc-refboard-TR0003667.json

### DIFF
--- a/templates/lgi/brcm972180hbc-refboard-TR0003667.json
+++ b/templates/lgi/brcm972180hbc-refboard-TR0003667.json
@@ -95,7 +95,7 @@
                 ]
             },
             {
-                "source": "/tmp/rialto-0",
+                "source": "/tmp/{id}",
                 "destination": "/tmp/rialto-0",
                 "type": "bind",
                 "options": [


### PR DESCRIPTION
/tmp/rialto-0 is changed to /tmp/{id}