### PR TITLE
Update RPI4 template

### DIFF
--- a/templates/generic/rpi4_reference_dunfell.json
+++ b/templates/generic/rpi4_reference_dunfell.json
@@ -150,6 +150,20 @@
                 "major": 226,
                 "minor": 0,
                 "access": "rw"
+            },
+            {
+                "type": "c",
+                "path": "/dev/dri/card1",
+                "major": 226,
+                "minor": 1,
+                "access": "rw"
+            },
+            {
+                "type": "c",
+                "path": "/dev/dri/renderD128",
+                "major": 226,
+                "minor": 128,
+                "access": "rw"
             }
         ],
         "gfxLibs": [
@@ -188,10 +202,6 @@
             {
                 "src": "/usr/lib/libessos.so.0",
                 "dst": "/usr/lib/libessos.so.0"
-            },
-            {
-                "src": "/usr/lib/dri/swrast_dri.so",
-                "dst": "/usr/lib/dri/swrast_dri.so"
             }
         ]
     },

--- a/templates/generic/rpi4_reference_dunfell_libs.json
+++ b/templates/generic/rpi4_reference_dunfell_libs.json
@@ -242,46 +242,6 @@
         },
         {
             "apiversions": [
-                "FDISK_2.26",
-                "FDISK_2.27",
-                "FDISK_2.28",
-                "FDISK_2.29",
-                "FDISK_2.30",
-                "FDISK_2.31",
-                "FDISK_2.32",
-                "FDISK_2.33",
-                "FDISK_2.35"
-            ],
-            "deps": [
-                "/lib/ld-linux-armhf.so.3",
-                "/lib/libblkid.so.1",
-                "/lib/libc.so.6",
-                "/lib/libuuid.so.1"
-            ],
-            "name": "/lib/libfdisk.so.1"
-        },
-        {
-            "apiversions": [
-                "FDISK_2.26",
-                "FDISK_2.27",
-                "FDISK_2.28",
-                "FDISK_2.29",
-                "FDISK_2.30",
-                "FDISK_2.31",
-                "FDISK_2.32",
-                "FDISK_2.33",
-                "FDISK_2.35"
-            ],
-            "deps": [
-                "/lib/ld-linux-armhf.so.3",
-                "/lib/libblkid.so.1",
-                "/lib/libc.so.6",
-                "/lib/libuuid.so.1"
-            ],
-            "name": "/lib/libfdisk.so.1.1.0"
-        },
-        {
-            "apiversions": [
                 "GLIBC_2.0",
                 "GCC_3.0",
                 "GCC_3.3",
@@ -300,24 +260,6 @@
                 "/lib/libc.so.6"
             ],
             "name": "/lib/libgcc_s.so.1"
-        },
-        {
-            "apiversions": [
-                "LIBHANDLE_1.0.3"
-            ],
-            "deps": [
-                "/lib/libc.so.6"
-            ],
-            "name": "/lib/libhandle.so.1"
-        },
-        {
-            "apiversions": [
-                "LIBHANDLE_1.0.3"
-            ],
-            "deps": [
-                "/lib/libc.so.6"
-            ],
-            "name": "/lib/libhandle.so.1.0.3"
         },
         {
             "apiversions": [
@@ -865,22 +807,6 @@
                 "/usr/lib/libyajl.so.2"
             ],
             "name": "/lib/libuinput.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libusb-1.0.so.0"
-            ],
-            "name": "/lib/libusb-0.1.so.4"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libusb-1.0.so.0"
-            ],
-            "name": "/lib/libusb-0.1.so.4.4.4"
         },
         {
             "apiversions": [],
@@ -1872,42 +1798,7 @@
             "apiversions": [],
             "deps": [
                 "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libgstbase-1.0.so.0",
-                "/usr/lib/libgstreamer-1.0.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/gstreamer-1.0/libgst-str-socket-sink.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libgstbase-1.0.so.0",
-                "/usr/lib/libgstreamer-1.0.so.0"
-            ],
-            "name": "/usr/lib/gstreamer-1.0/libgst-str-ttmlxml-filter.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/liba52.so.0",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libgobject-2.0.so.0",
-                "/usr/lib/libgstaudio-1.0.so.0",
-                "/usr/lib/libgstbase-1.0.so.0",
-                "/usr/lib/libgstreamer-1.0.so.0",
-                "/usr/lib/liborc-0.4.so.0"
-            ],
-            "name": "/usr/lib/gstreamer-1.0/libgsta52dec.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
+                "/lib/libdl.so.2",
                 "/lib/libgcc_s.so.1",
                 "/usr/lib/libaamp.so",
                 "/usr/lib/libaampjsbindings.so",
@@ -1947,6 +1838,7 @@
         {
             "apiversions": [],
             "deps": [
+                "/lib/libc.so.6",
                 "/usr/lib/libglib-2.0.so.0",
                 "/usr/lib/libgobject-2.0.so.0",
                 "/usr/lib/libgstaudio-1.0.so.0",
@@ -2083,23 +1975,6 @@
                 "/usr/lib/libgobject-2.0.so.0",
                 "/usr/lib/libgstbase-1.0.so.0",
                 "/usr/lib/libgstreamer-1.0.so.0",
-                "/usr/lib/libgstriff-1.0.so.0",
-                "/usr/lib/libgstrtp-1.0.so.0",
-                "/usr/lib/libgstrtsp-1.0.so.0",
-                "/usr/lib/libgstsdp-1.0.so.0",
-                "/usr/lib/libgsttag-1.0.so.0",
-                "/usr/lib/libgstvideo-1.0.so.0"
-            ],
-            "name": "/usr/lib/gstreamer-1.0/libgstasf.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libgobject-2.0.so.0",
-                "/usr/lib/libgstbase-1.0.so.0",
-                "/usr/lib/libgstreamer-1.0.so.0",
                 "/usr/lib/libgstrtp-1.0.so.0"
             ],
             "name": "/usr/lib/gstreamer-1.0/libgstasfmux.so"
@@ -2179,6 +2054,7 @@
         {
             "apiversions": [],
             "deps": [
+                "/lib/libc.so.6",
                 "/lib/libm.so.6",
                 "/usr/lib/libglib-2.0.so.0",
                 "/usr/lib/libgobject-2.0.so.0",
@@ -2241,6 +2117,7 @@
         {
             "apiversions": [],
             "deps": [
+                "/lib/libc.so.6",
                 "/lib/libm.so.6",
                 "/usr/lib/libglib-2.0.so.0",
                 "/usr/lib/libgobject-2.0.so.0",
@@ -2336,6 +2213,7 @@
         {
             "apiversions": [],
             "deps": [
+                "/lib/libc.so.6",
                 "/usr/lib/libcairo-gobject.so.2",
                 "/usr/lib/libcairo.so.2",
                 "/usr/lib/libglib-2.0.so.0",
@@ -2599,34 +2477,10 @@
                 "/lib/libc.so.6",
                 "/usr/lib/libglib-2.0.so.0",
                 "/usr/lib/libgobject-2.0.so.0",
-                "/usr/lib/libgstaudio-1.0.so.0",
-                "/usr/lib/libgstbase-1.0.so.0",
-                "/usr/lib/libgstreamer-1.0.so.0"
-            ],
-            "name": "/usr/lib/gstreamer-1.0/libgstdvdlpcmdec.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libgobject-2.0.so.0",
                 "/usr/lib/libgstreamer-1.0.so.0",
                 "/usr/lib/libgstvideo-1.0.so.0"
             ],
             "name": "/usr/lib/gstreamer-1.0/libgstdvdspu.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libgobject-2.0.so.0",
-                "/usr/lib/libgstbase-1.0.so.0",
-                "/usr/lib/libgstreamer-1.0.so.0",
-                "/usr/lib/libgstvideo-1.0.so.0"
-            ],
-            "name": "/usr/lib/gstreamer-1.0/libgstdvdsub.so"
         },
         {
             "apiversions": [],
@@ -2694,21 +2548,6 @@
                 "/usr/lib/libgstreamer-1.0.so.0"
             ],
             "name": "/usr/lib/gstreamer-1.0/libgstequalizer.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libgobject-2.0.so.0",
-                "/usr/lib/libgstbase-1.0.so.0",
-                "/usr/lib/libgstreamer-1.0.so.0",
-                "/usr/lib/libwayland-client.so.0",
-                "/usr/lib/libwesteros_compositor.so.0",
-                "/usr/lib/libwesteros_simplebuffer_client.so.0",
-                "/usr/lib/libwesteros_simpleshell_client.so.0"
-            ],
-            "name": "/usr/lib/gstreamer-1.0/libgstexternal.so"
         },
         {
             "apiversions": [],
@@ -3144,18 +2983,17 @@
             "apiversions": [],
             "deps": [
                 "/lib/libc.so.6",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/lib/libz.so.1",
-                "/usr/lib/libbz2.so.1",
+                "/usr/lib/libavcodec.so.58",
+                "/usr/lib/libavfilter.so.7",
+                "/usr/lib/libavformat.so.58",
+                "/usr/lib/libavutil.so.56",
                 "/usr/lib/libglib-2.0.so.0",
                 "/usr/lib/libgobject-2.0.so.0",
                 "/usr/lib/libgstaudio-1.0.so.0",
                 "/usr/lib/libgstbase-1.0.so.0",
                 "/usr/lib/libgstpbutils-1.0.so.0",
                 "/usr/lib/libgstreamer-1.0.so.0",
-                "/usr/lib/libgstvideo-1.0.so.0",
-                "/usr/lib/liblzma.so.5"
+                "/usr/lib/libgstvideo-1.0.so.0"
             ],
             "name": "/usr/lib/gstreamer-1.0/libgstlibav.so"
         },
@@ -3329,6 +3167,7 @@
         {
             "apiversions": [],
             "deps": [
+                "/lib/libc.so.6",
                 "/lib/libm.so.6",
                 "/usr/lib/libglib-2.0.so.0",
                 "/usr/lib/libgobject-2.0.so.0",
@@ -3571,20 +3410,6 @@
             "apiversions": [],
             "deps": [
                 "/lib/libc.so.6",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libgobject-2.0.so.0",
-                "/usr/lib/libgstbase-1.0.so.0",
-                "/usr/lib/libgstpbutils-1.0.so.0",
-                "/usr/lib/libgstreamer-1.0.so.0",
-                "/usr/lib/libgstrtsp-1.0.so.0",
-                "/usr/lib/libgstsdp-1.0.so.0"
-            ],
-            "name": "/usr/lib/gstreamer-1.0/libgstrealmedia.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
                 "/lib/libm.so.6",
                 "/usr/lib/libglib-2.0.so.0",
                 "/usr/lib/libgobject-2.0.so.0",
@@ -3619,24 +3444,6 @@
                 "/usr/lib/libgstvideo-1.0.so.0"
             ],
             "name": "/usr/lib/gstreamer-1.0/libgstrfbsrc.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libRialtoClient.so.1",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libgobject-2.0.so.0",
-                "/usr/lib/libgstapp-1.0.so.0",
-                "/usr/lib/libgstaudio-1.0.so.0",
-                "/usr/lib/libgstpbutils-1.0.so.0",
-                "/usr/lib/libgstreamer-1.0.so.0",
-                "/usr/lib/libocdmRialto.so.1",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/gstreamer-1.0/libgstrialtosinks.so"
         },
         {
             "apiversions": [],
@@ -3823,6 +3630,7 @@
         {
             "apiversions": [],
             "deps": [
+                "/lib/libc.so.6",
                 "/usr/lib/libglib-2.0.so.0",
                 "/usr/lib/libgobject-2.0.so.0",
                 "/usr/lib/libgstreamer-1.0.so.0",
@@ -4409,17 +4217,6 @@
                 "/usr/lib/libglib-2.0.so.0",
                 "/usr/lib/libgobject-2.0.so.0",
                 "/usr/lib/libgstbase-1.0.so.0",
-                "/usr/lib/libgstreamer-1.0.so.0"
-            ],
-            "name": "/usr/lib/gstreamer-1.0/libgstxingmux.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libgobject-2.0.so.0",
-                "/usr/lib/libgstbase-1.0.so.0",
                 "/usr/lib/libgstreamer-1.0.so.0",
                 "/usr/lib/libgstvideo-1.0.so.0"
             ],
@@ -4464,138 +4261,6 @@
             "apiversions": [],
             "deps": [
                 "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libasound.so.2",
-                "/usr/lib/libsamplerate.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/jack/audioadapter.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/librt.so.1",
-                "/usr/lib/libjackserver.so.0"
-            ],
-            "name": "/usr/lib/jack/inprocess.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libasound.so.2",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/jack/jack_alsa.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libasound.so.2",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/jack/jack_alsarawmidi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/jack/jack_dummy.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/jack/jack_loopback.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/jack/jack_net.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libsamplerate.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/jack/jack_netone.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/jack/jack_proxy.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/lib/librt.so.1",
-                "/usr/lib/libjackserver.so.0",
-                "/usr/lib/libsamplerate.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/jack/netadapter.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libgcc_s.so.1",
-                "/lib/libpthread.so.0",
-                "/lib/librt.so.1",
-                "/usr/lib/libjackserver.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/jack/netmanager.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libgcc_s.so.1",
-                "/lib/libpthread.so.0",
-                "/lib/librt.so.1",
-                "/usr/lib/libjackserver.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/jack/profiler.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
                 "/lib/libdl.so.2",
                 "/lib/libgcc_s.so.1",
                 "/lib/libm.so.6",
@@ -4625,28 +4290,6 @@
                 "/usr/lib/libstdc++.so.6"
             ],
             "name": "/usr/lib/lib++dfb-1.7.so.7.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libdbus-1.so.3",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/libsafec-3.5.1.so.3"
-            ],
-            "name": "/usr/lib/libBTMgr.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libdbus-1.so.3",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/libsafec-3.5.1.so.3"
-            ],
-            "name": "/usr/lib/libBTMgr.so.0.0.0"
         },
         {
             "apiversions": [],
@@ -4795,374 +4438,6 @@
         {
             "apiversions": [],
             "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libQt5Concurrent.so.5"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libQt5Concurrent.so.5.1"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libQt5Concurrent.so.5.1.1"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/ld-linux-armhf.so.3",
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/lib/libz.so.1",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libicui18n.so.66",
-                "/usr/lib/libicuuc.so.66",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libQt5Core.so.5"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/ld-linux-armhf.so.3",
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/lib/libz.so.1",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libicui18n.so.66",
-                "/usr/lib/libicuuc.so.66",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libQt5Core.so.5.1"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/ld-linux-armhf.so.3",
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/lib/libz.so.1",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libicui18n.so.66",
-                "/usr/lib/libicuuc.so.66",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libQt5Core.so.5.1.1"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libQt5DBus.so.5"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libQt5DBus.so.5.1"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libQt5DBus.so.5.1.1"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/lib/libz.so.1",
-                "/usr/lib/libGLESv2.so.2",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libpng16.so.16",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libQt5Gui.so.5"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/lib/libz.so.1",
-                "/usr/lib/libGLESv2.so.2",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libpng16.so.16",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libQt5Gui.so.5.1"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/lib/libz.so.1",
-                "/usr/lib/libGLESv2.so.2",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libpng16.so.16",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libQt5Gui.so.5.1.1"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libpthread.so.0",
-                "/lib/libz.so.1",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libcrypto.so.1.1",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libQt5Network.so.5"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libpthread.so.0",
-                "/lib/libz.so.1",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libcrypto.so.1.1",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libQt5Network.so.5.1"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libpthread.so.0",
-                "/lib/libz.so.1",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libcrypto.so.1.1",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libQt5Network.so.5.1.1"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libm.so.6",
-                "/usr/lib/libGLESv2.so.2",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libQt5Gui.so.5",
-                "/usr/lib/libQt5Widgets.so.5",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libQt5OpenGL.so.5"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libm.so.6",
-                "/usr/lib/libGLESv2.so.2",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libQt5Gui.so.5",
-                "/usr/lib/libQt5Widgets.so.5",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libQt5OpenGL.so.5.1"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libm.so.6",
-                "/usr/lib/libGLESv2.so.2",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libQt5Gui.so.5",
-                "/usr/lib/libQt5Widgets.so.5",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libQt5OpenGL.so.5.1.1"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libQt5Sql.so.5"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libQt5Sql.so.5.1"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libQt5Sql.so.5.1.1"
-        },
-        {
-            "apiversions": [],
-            "deps": [],
-            "name": "/usr/lib/libQt5Test.so.5"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libQt5Network.so.5",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libQt5WebSockets.so.5"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libQt5Network.so.5",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libQt5WebSockets.so.5.6"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libQt5Network.so.5",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libQt5WebSockets.so.5.6.2"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libQt5Gui.so.5",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libQt5Widgets.so.5"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libQt5Gui.so.5",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libQt5Widgets.so.5.1"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libQt5Gui.so.5",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libQt5Widgets.so.5.1.1"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libQt5Xml.so.5"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libQt5Xml.so.5.1"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libQt5Xml.so.5.1.1"
-        },
-        {
-            "apiversions": [],
-            "deps": [
                 "/lib/libc.so.6"
             ],
             "name": "/usr/lib/libRDKMfrLib.so.0"
@@ -5173,30 +4448,6 @@
                 "/lib/libc.so.6"
             ],
             "name": "/usr/lib/libRDKMfrLib.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/ld-linux-armhf.so.3",
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libprotobuf.so.22",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libRialtoClient.so.1"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/ld-linux-armhf.so.3",
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libprotobuf.so.22",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libRialtoClient.so.1.0.0"
         },
         {
             "apiversions": [],
@@ -5244,6 +4495,7 @@
             "deps": [
                 "/lib/libc.so.6",
                 "/lib/libgcc_s.so.1",
+                "/lib/libpthread.so.0",
                 "/usr/lib/libbreakpadwrapper.so.0",
                 "/usr/lib/libglib-2.0.so.0",
                 "/usr/lib/libsafec-3.5.1.so.3"
@@ -5255,6 +4507,7 @@
             "deps": [
                 "/lib/libc.so.6",
                 "/lib/libgcc_s.so.1",
+                "/lib/libpthread.so.0",
                 "/usr/lib/libbreakpadwrapper.so.0",
                 "/usr/lib/libglib-2.0.so.0",
                 "/usr/lib/libsafec-3.5.1.so.3"
@@ -5277,34 +4530,6 @@
                 "/usr/lib/libstdc++.so.6"
             ],
             "name": "/usr/lib/libTextToSpeechServiceClient.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libbreakpadwrapper.so.0",
-                "/usr/lib/libgthread-2.0.so.0",
-                "/usr/lib/librbus.so.0",
-                "/usr/lib/libsafec-3.5.1.so.3",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libTr69BusAgent.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libbreakpadwrapper.so.0",
-                "/usr/lib/libgthread-2.0.so.0",
-                "/usr/lib/librbus.so.0",
-                "/usr/lib/libsafec-3.5.1.so.3",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libTr69BusAgent.so.0.0.0"
         },
         {
             "apiversions": [],
@@ -5854,23 +5079,7 @@
                 "/usr/lib/libxml2.so.2",
                 "/usr/lib/libxslt.so.1"
             ],
-            "name": "/usr/lib/libWPEWebKit-1.0.so.3.10.11"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libm.so.6"
-            ],
-            "name": "/usr/lib/liba52.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libm.so.6"
-            ],
-            "name": "/usr/lib/liba52.so.0.0.0"
+            "name": "/usr/lib/libWPEWebKit-1.0.so.3.10.13"
         },
         {
             "apiversions": [],
@@ -5891,7 +5100,9 @@
                 "/usr/lib/libgobject-2.0.so.0",
                 "/usr/lib/libgstapp-1.0.so.0",
                 "/usr/lib/libgstreamer-1.0.so.0",
+                "/usr/lib/libgstvideo-1.0.so.0",
                 "/usr/lib/libmetrics.so",
+                "/usr/lib/libocdm.so.2",
                 "/usr/lib/libstdc++.so.6",
                 "/usr/lib/libsubtec.so",
                 "/usr/lib/libtr181api.so.0",
@@ -5912,34 +5123,6 @@
                 "/usr/lib/libstdc++.so.6"
             ],
             "name": "/usr/lib/libaampjsbindings.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libaamp.so",
-                "/usr/lib/libds.so",
-                "/usr/lib/libdshalcli.so",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libaampstub.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libaamp.so",
-                "/usr/lib/libds.so",
-                "/usr/lib/libdshalcli.so",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libaampstub.so.0.0.0"
         },
         {
             "apiversions": [],
@@ -6007,64 +5190,16 @@
             "name": "/usr/lib/libapm.so.1.0.0"
         },
         {
-            "apiversions": [
-                "IMMUNIX_1.0",
-                "APPARMOR_1.0",
-                "APPARMOR_1.1",
-                "APPARMOR_2.9",
-                "APPARMOR_2.10",
-                "APPARMOR_2.11",
-                "APPARMOR_2.13",
-                "APPARMOR_2.13.1",
-                "PRIVATE"
-            ],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libpthread.so.0"
-            ],
-            "name": "/usr/lib/libapparmor.so.1"
-        },
-        {
-            "apiversions": [
-                "IMMUNIX_1.0",
-                "APPARMOR_1.0",
-                "APPARMOR_1.1",
-                "APPARMOR_2.9",
-                "APPARMOR_2.10",
-                "APPARMOR_2.11",
-                "APPARMOR_2.13",
-                "APPARMOR_2.13.1",
-                "PRIVATE"
-            ],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libpthread.so.0"
-            ],
-            "name": "/usr/lib/libapparmor.so.1.6.2"
-        },
-        {
             "apiversions": [],
             "deps": [
                 "/lib/libc.so.6",
                 "/lib/libz.so.1",
                 "/usr/lib/libbz2.so.1",
-                "/usr/lib/liblzma.so.5",
-                "/usr/lib/liblzo2.so.2",
-                "/usr/lib/libxml2.so.2"
+                "/usr/lib/libcrypto.so.1.1",
+                "/usr/lib/libexpat.so.1",
+                "/usr/lib/libzstd.so.1"
             ],
-            "name": "/usr/lib/libarchive.so.13"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libz.so.1",
-                "/usr/lib/libbz2.so.1",
-                "/usr/lib/liblzma.so.5",
-                "/usr/lib/liblzo2.so.2",
-                "/usr/lib/libxml2.so.2"
-            ],
-            "name": "/usr/lib/libarchive.so.13.4.2"
+            "name": "/usr/lib/libarchive.so.19"
         },
         {
             "apiversions": [
@@ -6175,34 +5310,148 @@
             "name": "/usr/lib/libattr.so.1.1.2448"
         },
         {
-            "apiversions": [],
+            "apiversions": [
+                "LIBAVCODEC_58"
+            ],
             "deps": [
                 "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
                 "/lib/libm.so.6",
                 "/lib/libpthread.so.0",
-                "/usr/lib/libbreakpadwrapper.so.0",
-                "/usr/lib/libprivilege.so.0",
-                "/usr/lib/librmfAudioCapture.so.0",
-                "/usr/lib/libsafec-3.5.1.so.3",
-                "/usr/lib/libstdc++.so.6"
+                "/lib/libz.so.1",
+                "/usr/lib/libavutil.so.56",
+                "/usr/lib/liblzma.so.5",
+                "/usr/lib/libswresample.so.3",
+                "/usr/lib/libtheoradec.so.1",
+                "/usr/lib/libtheoraenc.so.1"
             ],
-            "name": "/usr/lib/libaudiocapturemgr.so.0"
+            "name": "/usr/lib/libavcodec.so.58"
         },
         {
-            "apiversions": [],
+            "apiversions": [
+                "LIBAVCODEC_58"
+            ],
             "deps": [
                 "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
                 "/lib/libm.so.6",
                 "/lib/libpthread.so.0",
-                "/usr/lib/libbreakpadwrapper.so.0",
-                "/usr/lib/libprivilege.so.0",
-                "/usr/lib/librmfAudioCapture.so.0",
-                "/usr/lib/libsafec-3.5.1.so.3",
-                "/usr/lib/libstdc++.so.6"
+                "/lib/libz.so.1",
+                "/usr/lib/libavutil.so.56",
+                "/usr/lib/liblzma.so.5",
+                "/usr/lib/libswresample.so.3",
+                "/usr/lib/libtheoradec.so.1",
+                "/usr/lib/libtheoraenc.so.1"
             ],
-            "name": "/usr/lib/libaudiocapturemgr.so.0.0.0"
+            "name": "/usr/lib/libavcodec.so.58.54.100"
+        },
+        {
+            "apiversions": [
+                "LIBAVFILTER_7"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libavcodec.so.58",
+                "/usr/lib/libavformat.so.58",
+                "/usr/lib/libavresample.so.4",
+                "/usr/lib/libavutil.so.56",
+                "/usr/lib/libswresample.so.3",
+                "/usr/lib/libswscale.so.5"
+            ],
+            "name": "/usr/lib/libavfilter.so.7"
+        },
+        {
+            "apiversions": [
+                "LIBAVFILTER_7"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libavcodec.so.58",
+                "/usr/lib/libavformat.so.58",
+                "/usr/lib/libavresample.so.4",
+                "/usr/lib/libavutil.so.56",
+                "/usr/lib/libswresample.so.3",
+                "/usr/lib/libswscale.so.5"
+            ],
+            "name": "/usr/lib/libavfilter.so.7.57.100"
+        },
+        {
+            "apiversions": [
+                "LIBAVFORMAT_58"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/libz.so.1",
+                "/usr/lib/libavcodec.so.58",
+                "/usr/lib/libavutil.so.56",
+                "/usr/lib/libbz2.so.1"
+            ],
+            "name": "/usr/lib/libavformat.so.58"
+        },
+        {
+            "apiversions": [
+                "LIBAVFORMAT_58"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/libz.so.1",
+                "/usr/lib/libavcodec.so.58",
+                "/usr/lib/libavutil.so.56",
+                "/usr/lib/libbz2.so.1"
+            ],
+            "name": "/usr/lib/libavformat.so.58.29.100"
+        },
+        {
+            "apiversions": [
+                "LIBAVRESAMPLE_4"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libavutil.so.56"
+            ],
+            "name": "/usr/lib/libavresample.so.4"
+        },
+        {
+            "apiversions": [
+                "LIBAVRESAMPLE_4"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libavutil.so.56"
+            ],
+            "name": "/usr/lib/libavresample.so.4.0.0"
+        },
+        {
+            "apiversions": [
+                "LIBAVUTIL_56"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0"
+            ],
+            "name": "/usr/lib/libavutil.so.56"
+        },
+        {
+            "apiversions": [
+                "LIBAVUTIL_56"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0"
+            ],
+            "name": "/usr/lib/libavutil.so.56.31.100"
         },
         {
             "apiversions": [],
@@ -6239,36 +5488,6 @@
                 "/lib/libpthread.so.0",
                 "/usr/lib/libstdc++.so.6"
             ],
-            "name": "/usr/lib/libboost_chrono.so.1"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libboost_chrono.so.1.72"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libboost_chrono.so.1.72.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
             "name": "/usr/lib/libboost_filesystem.so.1"
         },
         {
@@ -6290,36 +5509,6 @@
                 "/usr/lib/libstdc++.so.6"
             ],
             "name": "/usr/lib/libboost_filesystem.so.1.72.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libboost_regex.so.1"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libboost_regex.so.1.72"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libboost_regex.so.1.72.0"
         },
         {
             "apiversions": [],
@@ -6529,176 +5718,6 @@
             "apiversions": [],
             "deps": [
                 "/lib/libc.so.6",
-                "/usr/lib/libdbus-1.so.3",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/libsafec-3.5.1.so.3"
-            ],
-            "name": "/usr/lib/libbtrCore.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libdbus-1.so.3",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/libsafec-3.5.1.so.3"
-            ],
-            "name": "/usr/lib/libbtrCore.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/librmfAudioCapture.so.0",
-                "/usr/lib/libsafec-3.5.1.so.3"
-            ],
-            "name": "/usr/lib/libbtrMgrAudioCapture.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/librmfAudioCapture.so.0",
-                "/usr/lib/libsafec-3.5.1.so.3"
-            ],
-            "name": "/usr/lib/libbtrMgrAudioCapture.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/librdkloggers.so.0"
-            ],
-            "name": "/usr/lib/libbtrMgrColumbo.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/librdkloggers.so.0"
-            ],
-            "name": "/usr/lib/libbtrMgrColumbo.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libcrypto.so.1.1",
-                "/usr/lib/libsafec-3.5.1.so.3",
-                "/usr/lib/libssl.so.1.1"
-            ],
-            "name": "/usr/lib/libbtrMgrLeOnboarding.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libcrypto.so.1.1",
-                "/usr/lib/libsafec-3.5.1.so.3",
-                "/usr/lib/libssl.so.1.1"
-            ],
-            "name": "/usr/lib/libbtrMgrLeOnboarding.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libcjson.so.1",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/libsafec-3.5.1.so.3"
-            ],
-            "name": "/usr/lib/libbtrMgrPersistInterface.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libcjson.so.1",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/libsafec-3.5.1.so.3"
-            ],
-            "name": "/usr/lib/libbtrMgrPersistInterface.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libgobject-2.0.so.0",
-                "/usr/lib/libgstapp-1.0.so.0",
-                "/usr/lib/libgstreamer-1.0.so.0",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/libsafec-3.5.1.so.3"
-            ],
-            "name": "/usr/lib/libbtrMgrStreamIn.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libgobject-2.0.so.0",
-                "/usr/lib/libgstapp-1.0.so.0",
-                "/usr/lib/libgstreamer-1.0.so.0",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/libsafec-3.5.1.so.3"
-            ],
-            "name": "/usr/lib/libbtrMgrStreamIn.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libgobject-2.0.so.0",
-                "/usr/lib/libgstapp-1.0.so.0",
-                "/usr/lib/libgstreamer-1.0.so.0",
-                "/usr/lib/librdkloggers.so.0"
-            ],
-            "name": "/usr/lib/libbtrMgrStreamOut.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libgobject-2.0.so.0",
-                "/usr/lib/libgstapp-1.0.so.0",
-                "/usr/lib/libgstreamer-1.0.so.0",
-                "/usr/lib/librdkloggers.so.0"
-            ],
-            "name": "/usr/lib/libbtrMgrStreamOut.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/libsafec-3.5.1.so.3"
-            ],
-            "name": "/usr/lib/libbtrMgrSysDiag.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/libsafec-3.5.1.so.3"
-            ],
-            "name": "/usr/lib/libbtrMgrSysDiag.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
                 "/lib/libpthread.so.0",
                 "/usr/lib/libbreakpadwrapper.so.0",
                 "/usr/lib/libccspinterface.so.0",
@@ -6716,7 +5735,8 @@
                 "/usr/lib/libscheduler.so.0",
                 "/usr/lib/libsecure_wrapper.so.0",
                 "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libt2utils.so.0"
+                "/usr/lib/libt2utils.so.0",
+                "/usr/lib/libwebconfig_framework.so.0"
             ],
             "name": "/usr/lib/libbulkdata.so"
         },
@@ -6741,7 +5761,8 @@
                 "/usr/lib/libscheduler.so.0",
                 "/usr/lib/libsecure_wrapper.so.0",
                 "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libt2utils.so.0"
+                "/usr/lib/libt2utils.so.0",
+                "/usr/lib/libwebconfig_framework.so.0"
             ],
             "name": "/usr/lib/libbulkdata.so.0"
         },
@@ -6766,22 +5787,10 @@
                 "/usr/lib/libscheduler.so.0",
                 "/usr/lib/libsecure_wrapper.so.0",
                 "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libt2utils.so.0"
+                "/usr/lib/libt2utils.so.0",
+                "/usr/lib/libwebconfig_framework.so.0"
             ],
             "name": "/usr/lib/libbulkdata.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libboost_chrono.so.1.72.0",
-                "/usr/lib/libboost_thread.so.1.72.0",
-                "/usr/lib/libglog.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libbuqu.so"
         },
         {
             "apiversions": [],
@@ -6835,7 +5844,7 @@
                 "/usr/lib/libpixman-1.so.0",
                 "/usr/lib/libpng16.so.16"
             ],
-            "name": "/usr/lib/libcairo-gobject.so.2.11400.6"
+            "name": "/usr/lib/libcairo-gobject.so.2.11600.0"
         },
         {
             "apiversions": [],
@@ -6871,7 +5880,7 @@
                 "/usr/lib/libpixman-1.so.0",
                 "/usr/lib/libpng16.so.16"
             ],
-            "name": "/usr/lib/libcairo.so.2.11400.6"
+            "name": "/usr/lib/libcairo.so.2.11600.0"
         },
         {
             "apiversions": [],
@@ -6941,15 +5950,6 @@
         {
             "apiversions": [],
             "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0"
-            ],
-            "name": "/usr/lib/libcivetweb.so.1.10.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
                 "/lib/libc.so.6"
             ],
             "name": "/usr/lib/libcjson.so.1"
@@ -6976,15 +5976,6 @@
                 "/usr/lib/libcjson.so.1"
             ],
             "name": "/usr/lib/libcjson_utils.so.1.7.13"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libcjson.so.1",
-                "/usr/lib/libtrower-base64.so.1.0.0"
-            ],
-            "name": "/usr/lib/libcjwt.so"
         },
         {
             "apiversions": [],
@@ -7021,72 +6012,12 @@
             "apiversions": [],
             "deps": [
                 "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/lib/libsystemd.so.0",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libcjson.so.1",
-                "/usr/lib/libcurl.so.4",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libnlmonitor.so.0",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/librfcapi.so.0",
-                "/usr/lib/libsafec-3.5.1.so.3",
-                "/usr/lib/libsecure_wrapper.so.0",
-                "/usr/lib/libsqlite3.so.0",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtelemetry_msgsender.so.0",
-                "/usr/lib/libwifihal.so.0"
-            ],
-            "name": "/usr/lib/libconnectivitytest.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/lib/libsystemd.so.0",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libcjson.so.1",
-                "/usr/lib/libcurl.so.4",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libnlmonitor.so.0",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/librfcapi.so.0",
-                "/usr/lib/libsafec-3.5.1.so.3",
-                "/usr/lib/libsecure_wrapper.so.0",
-                "/usr/lib/libsqlite3.so.0",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtelemetry_msgsender.so.0",
-                "/usr/lib/libwifihal.so.0"
-            ],
-            "name": "/usr/lib/libconnectivitytest.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
                 "/lib/libdl.so.2",
                 "/lib/libpthread.so.0",
                 "/lib/librt.so.1",
                 "/usr/lib/libvcos.so"
             ],
             "name": "/usr/lib/libcontainers.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libcimplog.so.1.0.0",
-                "/usr/lib/libcjson.so.1",
-                "/usr/lib/libmsgpackc.so.2",
-                "/usr/lib/librbus.so.0",
-                "/usr/lib/libwdmp-c.so"
-            ],
-            "name": "/usr/lib/libcpeabs.so"
         },
         {
             "apiversions": [],
@@ -7315,32 +6246,6 @@
             "apiversions": [],
             "deps": [
                 "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libds.so",
-                "/usr/lib/libdshalcli.so",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libdevicesettingsstub.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libds.so",
-                "/usr/lib/libdshalcli.so",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libdevicesettingsstub.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
                 "/lib/libdl.so.2",
                 "/lib/libgcc_s.so.1",
                 "/lib/libm.so.6",
@@ -7492,54 +6397,6 @@
             "apiversions": [],
             "deps": [
                 "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libds-hal.so.0",
-                "/usr/lib/libdshalsrv.so",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libdshalstub.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libds-hal.so.0",
-                "/usr/lib/libdshalsrv.so",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libdshalstub.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libDtcpMgr-1.0.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libdtcpstub.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libDtcpMgr-1.0.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libdtcpstub.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
                 "/lib/libpthread.so.0"
             ],
             "name": "/usr/lib/libdtovl.so"
@@ -7583,26 +6440,6 @@
         {
             "apiversions": [],
             "deps": [
-                "/lib/ld-linux-armhf.so.3",
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libdvbsubdecoder.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/ld-linux-armhf.so.3",
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libdvbsubdecoder.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
                 "/lib/libc.so.6",
                 "/lib/libgcc_s.so.1",
                 "/lib/libm.so.6",
@@ -7614,7 +6451,6 @@
                 "/usr/lib/libdvrsink.so.0",
                 "/usr/lib/libglib-2.0.so.0",
                 "/usr/lib/libhnsource.so.0",
-                "/usr/lib/libqamsrc.so.0",
                 "/usr/lib/libsafec-3.5.1.so.3",
                 "/usr/lib/libstdc++.so.6",
                 "/usr/lib/libtinyxml.so.2.6.2"
@@ -7635,7 +6471,6 @@
                 "/usr/lib/libdvrsink.so.0",
                 "/usr/lib/libglib-2.0.so.0",
                 "/usr/lib/libhnsource.so.0",
-                "/usr/lib/libqamsrc.so.0",
                 "/usr/lib/libsafec-3.5.1.so.3",
                 "/usr/lib/libstdc++.so.6",
                 "/usr/lib/libtinyxml.so.2.6.2"
@@ -7794,22 +6629,6 @@
             "apiversions": [],
             "deps": [
                 "/lib/libc.so.6",
-                "/lib/libm.so.6"
-            ],
-            "name": "/usr/lib/libev.so.4"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libm.so.6"
-            ],
-            "name": "/usr/lib/libev.so.4.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
                 "/lib/libpthread.so.0"
             ],
             "name": "/usr/lib/libevent-2.1.so.7"
@@ -7930,26 +6749,6 @@
             "apiversions": [],
             "deps": [
                 "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libfirebolt_compliancestub.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libfirebolt_compliancestub.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
                 "/lib/libpthread.so.0",
                 "/lib/libuuid.so.1",
                 "/usr/lib/libexpat.so.1",
@@ -8019,62 +6818,6 @@
                 "/lib/libc.so.6"
             ],
             "name": "/usr/lib/libfribidi.so.0.4.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libusb-1.0.so.0"
-            ],
-            "name": "/usr/lib/libftdi1.so.2"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libusb-1.0.so.0"
-            ],
-            "name": "/usr/lib/libftdi1.so.2.4.0"
-        },
-        {
-            "apiversions": [
-                "FUSE_UNVERSIONED",
-                "FUSE_2.2",
-                "FUSE_2.4",
-                "FUSE_2.5",
-                "FUSE_2.6",
-                "FUSE_2.7",
-                "FUSE_2.7.5",
-                "FUSE_2.8",
-                "FUSE_2.9",
-                "FUSE_2.9.1"
-            ],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0"
-            ],
-            "name": "/usr/lib/libfuse.so.2"
-        },
-        {
-            "apiversions": [
-                "FUSE_UNVERSIONED",
-                "FUSE_2.2",
-                "FUSE_2.4",
-                "FUSE_2.5",
-                "FUSE_2.6",
-                "FUSE_2.7",
-                "FUSE_2.7.5",
-                "FUSE_2.8",
-                "FUSE_2.9",
-                "FUSE_2.9.1"
-            ],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0"
-            ],
-            "name": "/usr/lib/libfuse.so.2.9.9"
         },
         {
             "apiversions": [],
@@ -8281,28 +7024,6 @@
             "apiversions": [],
             "deps": [
                 "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libunwind.so.8"
-            ],
-            "name": "/usr/lib/libglog.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libunwind.so.8"
-            ],
-            "name": "/usr/lib/libglog.so.0.3.5"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
                 "/lib/libdl.so.2",
                 "/lib/libpthread.so.0",
                 "/usr/lib/libglib-2.0.so.0"
@@ -8377,6 +7098,7 @@
             "apiversions": [],
             "deps": [
                 "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
                 "/usr/lib/libffi.so.7",
                 "/usr/lib/libglib-2.0.so.0"
             ],
@@ -8386,6 +7108,7 @@
             "apiversions": [],
             "deps": [
                 "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
                 "/usr/lib/libffi.so.7",
                 "/usr/lib/libglib-2.0.so.0"
             ],
@@ -9481,28 +8204,6 @@
         {
             "apiversions": [],
             "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libiarmbusstub.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libiarmbusstub.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
                 "/lib/libc.so.6"
             ],
             "name": "/usr/lib/libiarmmgrs-deepsleep-hal.so.0"
@@ -9648,6 +8349,7 @@
             "apiversions": [],
             "deps": [
                 "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
                 "/usr/lib/libical.so.3"
             ],
             "name": "/usr/lib/libicalvcal.so.3"
@@ -9656,6 +8358,7 @@
             "apiversions": [],
             "deps": [
                 "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
                 "/usr/lib/libical.so.3"
             ],
             "name": "/usr/lib/libicalvcal.so.3.0.7"
@@ -9732,24 +8435,6 @@
         },
         {
             "apiversions": [
-                "LIBIDN_1.0"
-            ],
-            "deps": [
-                "/lib/libc.so.6"
-            ],
-            "name": "/usr/lib/libidn.so.12"
-        },
-        {
-            "apiversions": [
-                "LIBIDN_1.0"
-            ],
-            "deps": [
-                "/lib/libc.so.6"
-            ],
-            "name": "/usr/lib/libidn.so.12.6.0"
-        },
-        {
-            "apiversions": [
                 "IDN2_0.0.0",
                 "IDN2_2.1.0"
             ],
@@ -9787,62 +8472,6 @@
                 "/usr/lib/libmbedx509.so.0"
             ],
             "name": "/usr/lib/libiksemel.so.3.1.1"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/liblog4c.so.3",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libinbsectionfilter.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/liblog4c.so.3",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libinbsectionfilter.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libinbsectionfilter.so.0",
-                "/usr/lib/liboobsectionfilter.so.0",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/librfcapi.so.0",
-                "/usr/lib/libsectionfilter.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libinbsimanager.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libinbsectionfilter.so.0",
-                "/usr/lib/liboobsectionfilter.so.0",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/librfcapi.so.0",
-                "/usr/lib/libsectionfilter.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libinbsimanager.so.0.0.0"
         },
         {
             "apiversions": [],
@@ -9907,148 +8536,6 @@
                 "/lib/libc.so.6"
             ],
             "name": "/usr/lib/libip6tc.so.2.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/lib/librt.so.1",
-                "/lib/libsystemd.so.0",
-                "/lib/libuuid.so.1",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libcjson.so.1",
-                "/usr/lib/libcrypto.so.1.1",
-                "/usr/lib/libcurl.so.4",
-                "/usr/lib/libsafec-3.5.1.so.3",
-                "/usr/lib/libssl.so.1.1",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libyajl.so.2"
-            ],
-            "name": "/usr/lib/libipdvr.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/lib/librt.so.1",
-                "/lib/libsystemd.so.0",
-                "/lib/libuuid.so.1",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libcjson.so.1",
-                "/usr/lib/libcrypto.so.1.1",
-                "/usr/lib/libcurl.so.4",
-                "/usr/lib/libsafec-3.5.1.so.3",
-                "/usr/lib/libssl.so.1.1",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libyajl.so.2"
-            ],
-            "name": "/usr/lib/libipdvr.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc.so.0"
-            ],
-            "name": "/usr/lib/libirrecord.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc.so.0"
-            ],
-            "name": "/usr/lib/libirrecord.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/lib/librt.so.1",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libjack.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/lib/librt.so.1",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libjack.so.0.1.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/lib/librt.so.1",
-                "/usr/lib/libsamplerate.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libjacknet.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/lib/librt.so.1",
-                "/usr/lib/libsamplerate.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libjacknet.so.0.1.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/lib/librt.so.1",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libjackserver.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/lib/librt.so.1",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libjackserver.so.0.1.0"
         },
         {
             "apiversions": [],
@@ -10209,102 +8696,9 @@
         {
             "apiversions": [],
             "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libledmgr_extended.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libledmgr_extended.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libm.so.6",
-                "/usr/lib/libcjson.so.1",
-                "/usr/lib/libmsgpackc.so.2",
-                "/usr/lib/libnanomsg.so.5",
-                "/usr/lib/libtrower-base64.so.1.0.0",
-                "/usr/lib/libwrp-c.so"
-            ],
-            "name": "/usr/lib/liblibparodus.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
                 "/lib/libc.so.6"
             ],
             "name": "/usr/lib/liblinenoise.so.1.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libudev.so.1",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/liblirc.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libudev.so.1",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/liblirc.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libudev.so.1"
-            ],
-            "name": "/usr/lib/liblirc_client.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libudev.so.1"
-            ],
-            "name": "/usr/lib/liblirc_client.so.0.5.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libudev.so.1"
-            ],
-            "name": "/usr/lib/liblirc_driver.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libudev.so.1"
-            ],
-            "name": "/usr/lib/liblirc_driver.so.0.0.0"
         },
         {
             "apiversions": [],
@@ -10321,34 +8715,6 @@
                 "/lib/libpthread.so.0"
             ],
             "name": "/usr/lib/liblog4c.so.3.3.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/ld-linux-armhf.so.3",
-                "/lib/libc.so.6",
-                "/lib/libcap.so.2",
-                "/lib/libgcc_s.so.1",
-                "/lib/libpthread.so.0",
-                "/lib/libutil.so.1",
-                "/usr/lib/libcrypto.so.1.1",
-                "/usr/lib/libssl.so.1.1"
-            ],
-            "name": "/usr/lib/liblxc.so.1"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/ld-linux-armhf.so.3",
-                "/lib/libc.so.6",
-                "/lib/libcap.so.2",
-                "/lib/libgcc_s.so.1",
-                "/lib/libpthread.so.0",
-                "/lib/libutil.so.1",
-                "/usr/lib/libcrypto.so.1.1",
-                "/usr/lib/libssl.so.1.1"
-            ],
-            "name": "/usr/lib/liblxc.so.1.7.0"
         },
         {
             "apiversions": [
@@ -10644,24 +9010,6 @@
             "name": "/usr/lib/libmsgpackc.so.2.0.0"
         },
         {
-            "apiversions": [],
-            "deps": [
-                "/lib/libanl.so.1",
-                "/lib/libc.so.6",
-                "/lib/libpthread.so.0"
-            ],
-            "name": "/usr/lib/libnanomsg.so.5"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libanl.so.1",
-                "/lib/libc.so.6",
-                "/lib/libpthread.so.0"
-            ],
-            "name": "/usr/lib/libnanomsg.so.5.1.0"
-        },
-        {
             "apiversions": [
                 "NEON_0_29",
                 "NEON_0_30"
@@ -10692,74 +9040,6 @@
         {
             "apiversions": [],
             "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libcrypto.so.1.1",
-                "/usr/lib/libssl.so.1.1"
-            ],
-            "name": "/usr/lib/libnetsnmp.so.35"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libcrypto.so.1.1",
-                "/usr/lib/libssl.so.1.1"
-            ],
-            "name": "/usr/lib/libnetsnmp.so.35.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libnetsnmp.so.35"
-            ],
-            "name": "/usr/lib/libnetsnmpagent.so.35"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libnetsnmp.so.35"
-            ],
-            "name": "/usr/lib/libnetsnmpagent.so.35.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [],
-            "name": "/usr/lib/libnetsnmphelpers.so.35"
-        },
-        {
-            "apiversions": [],
-            "deps": [],
-            "name": "/usr/lib/libnetsnmphelpers.so.35.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/usr/lib/libnetsnmp.so.35",
-                "/usr/lib/libnetsnmpagent.so.35",
-                "/usr/lib/libpci.so.3",
-                "/usr/lib/libpcre.so.1"
-            ],
-            "name": "/usr/lib/libnetsnmpmibs.so.35"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/usr/lib/libnetsnmp.so.35",
-                "/usr/lib/libnetsnmpagent.so.35",
-                "/usr/lib/libpci.so.3",
-                "/usr/lib/libpcre.so.1"
-            ],
-            "name": "/usr/lib/libnetsnmpmibs.so.35.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
                 "/lib/libc.so.6"
             ],
             "name": "/usr/lib/libnettle.so.4"
@@ -10770,14 +9050,6 @@
                 "/lib/libc.so.6"
             ],
             "name": "/usr/lib/libnettle.so.4.7"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libcares.so.2"
-            ],
-            "name": "/usr/lib/libnghttp2.so.14.16.1"
         },
         {
             "apiversions": [
@@ -10811,38 +9083,6 @@
         },
         {
             "apiversions": [
-                "libnl_3",
-                "libnl_3_2_28"
-            ],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libnl-3.so.200",
-                "/usr/lib/libnl-genl-3.so.200",
-                "/usr/lib/libnl-nf-3.so.200",
-                "/usr/lib/libnl-route-3.so.200"
-            ],
-            "name": "/usr/lib/libnl-cli-3.so.200"
-        },
-        {
-            "apiversions": [
-                "libnl_3",
-                "libnl_3_2_28"
-            ],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libnl-3.so.200",
-                "/usr/lib/libnl-genl-3.so.200",
-                "/usr/lib/libnl-nf-3.so.200",
-                "/usr/lib/libnl-route-3.so.200"
-            ],
-            "name": "/usr/lib/libnl-cli-3.so.200.26.0"
-        },
-        {
-            "apiversions": [
                 "libnl_3"
             ],
             "deps": [
@@ -10862,52 +9102,6 @@
                 "/usr/lib/libnl-3.so.200"
             ],
             "name": "/usr/lib/libnl-genl-3.so.200.26.0"
-        },
-        {
-            "apiversions": [
-                "libnl_3"
-            ],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libnl-3.so.200"
-            ],
-            "name": "/usr/lib/libnl-idiag-3.so.200"
-        },
-        {
-            "apiversions": [
-                "libnl_3"
-            ],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libnl-3.so.200"
-            ],
-            "name": "/usr/lib/libnl-idiag-3.so.200.26.0"
-        },
-        {
-            "apiversions": [
-                "libnl_3"
-            ],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libnl-3.so.200",
-                "/usr/lib/libnl-route-3.so.200"
-            ],
-            "name": "/usr/lib/libnl-nf-3.so.200"
-        },
-        {
-            "apiversions": [
-                "libnl_3"
-            ],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libnl-3.so.200",
-                "/usr/lib/libnl-route-3.so.200"
-            ],
-            "name": "/usr/lib/libnl-nf-3.so.200.26.0"
         },
         {
             "apiversions": [
@@ -10946,152 +9140,6 @@
         {
             "apiversions": [],
             "deps": [
-                "/lib/libc.so.6",
-                "/lib/libpthread.so.0"
-            ],
-            "name": "/usr/lib/libnl/cli/cls/basic.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libpthread.so.0"
-            ],
-            "name": "/usr/lib/libnl/cli/cls/cgroup.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libpthread.so.0"
-            ],
-            "name": "/usr/lib/libnl/cli/qdisc/bfifo.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libpthread.so.0"
-            ],
-            "name": "/usr/lib/libnl/cli/qdisc/blackhole.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libpthread.so.0"
-            ],
-            "name": "/usr/lib/libnl/cli/qdisc/fq_codel.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libpthread.so.0"
-            ],
-            "name": "/usr/lib/libnl/cli/qdisc/hfsc.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libpthread.so.0"
-            ],
-            "name": "/usr/lib/libnl/cli/qdisc/htb.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libpthread.so.0"
-            ],
-            "name": "/usr/lib/libnl/cli/qdisc/ingress.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libpthread.so.0"
-            ],
-            "name": "/usr/lib/libnl/cli/qdisc/pfifo.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libpthread.so.0"
-            ],
-            "name": "/usr/lib/libnl/cli/qdisc/plug.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libbreakpadwrapper.so.0",
-                "/usr/lib/libnl-3.so.200",
-                "/usr/lib/libnl-cli-3.so.200",
-                "/usr/lib/libnl-genl-3.so.200",
-                "/usr/lib/libnl-nf-3.so.200",
-                "/usr/lib/libnl-route-3.so.200",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libnlmonitor.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libbreakpadwrapper.so.0",
-                "/usr/lib/libnl-3.so.200",
-                "/usr/lib/libnl-cli-3.so.200",
-                "/usr/lib/libnl-genl-3.so.200",
-                "/usr/lib/libnl-nf-3.so.200",
-                "/usr/lib/libnl-route-3.so.200",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libnlmonitor.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/ld-linux-armhf.so.3",
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libatomic.so.1",
-                "/usr/lib/libcrypto.so.1.1",
-                "/usr/lib/libssl.so.1.1",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libnode.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/ld-linux-armhf.so.3",
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libatomic.so.1",
-                "/usr/lib/libcrypto.so.1.1",
-                "/usr/lib/libssl.so.1.1",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libnode.so.64"
-        },
-        {
-            "apiversions": [],
-            "deps": [
                 "/lib/ld-linux-armhf.so.3",
                 "/lib/libc.so.6",
                 "/lib/libpthread.so.0",
@@ -11110,34 +9158,6 @@
                 "/usr/lib/libssl.so.1.1"
             ],
             "name": "/usr/lib/libnopoll.so.0.0.0"
-        },
-        {
-            "apiversions": [
-                "LIBNSL_1.0",
-                "LIBNSL_1.0.1",
-                "LIBNSL_1.0.2",
-                "LIBNSL_PRIVATE"
-            ],
-            "deps": [
-                "/lib/ld-linux-armhf.so.3",
-                "/lib/libc.so.6",
-                "/usr/lib/libtirpc.so.3"
-            ],
-            "name": "/usr/lib/libnsl.so.2"
-        },
-        {
-            "apiversions": [
-                "LIBNSL_1.0",
-                "LIBNSL_1.0.1",
-                "LIBNSL_1.0.2",
-                "LIBNSL_PRIVATE"
-            ],
-            "deps": [
-                "/lib/ld-linux-armhf.so.3",
-                "/lib/libc.so.6",
-                "/usr/lib/libtirpc.so.3"
-            ],
-            "name": "/usr/lib/libnsl.so.2.0.0"
         },
         {
             "apiversions": [],
@@ -11201,32 +9221,6 @@
             "deps": [
                 "/lib/libc.so.6",
                 "/lib/libgcc_s.so.1",
-                "/usr/lib/libRialtoClient.so.1",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libgobject-2.0.so.0",
-                "/usr/lib/libgstreamer-1.0.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libocdmRialto.so.1"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libRialtoClient.so.1",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libgobject-2.0.so.0",
-                "/usr/lib/libgstreamer-1.0.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libocdmRialto.so.1.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
                 "/lib/libm.so.6",
                 "/usr/lib/libIARMBus.so.0",
                 "/usr/lib/librfcapi.so.0",
@@ -11280,122 +9274,6 @@
             "apiversions": [],
             "deps": [
                 "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/liblog4c.so.3",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/liboobsectionfilter.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/liblog4c.so.3",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/liboobsectionfilter.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/librfcapi.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/liboobsicache.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/librfcapi.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/liboobsicache.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/librfcapi.so.0",
-                "/usr/lib/libsecure_wrapper.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/liboobsimanager.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/librfcapi.so.0",
-                "/usr/lib/libsecure_wrapper.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/liboobsimanager.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libgobject-2.0.so.0",
-                "/usr/lib/libgstbase-1.0.so.0",
-                "/usr/lib/libgstreamer-1.0.so.0",
-                "/usr/lib/liblog4c.so.3",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/librfcapi.so.0",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtinyxml.so.2.6.2"
-            ],
-            "name": "/usr/lib/liboobsimgrstub.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libgobject-2.0.so.0",
-                "/usr/lib/libgstbase-1.0.so.0",
-                "/usr/lib/libgstreamer-1.0.so.0",
-                "/usr/lib/liblog4c.so.3",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/librfcapi.so.0",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtinyxml.so.2.6.2"
-            ],
-            "name": "/usr/lib/liboobsimgrstub.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
                 "/lib/libdl.so.2",
                 "/lib/libm.so.6",
                 "/lib/libpthread.so.0",
@@ -11410,24 +9288,6 @@
                 "/usr/lib/libwayland-server.so.0"
             ],
             "name": "/usr/lib/libopenmaxil.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libarchive.so.13",
-                "/usr/lib/libsolv.so.1"
-            ],
-            "name": "/usr/lib/libopkg.so.1"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libarchive.so.13",
-                "/usr/lib/libsolv.so.1"
-            ],
-            "name": "/usr/lib/libopkg.so.1.0.0"
         },
         {
             "apiversions": [],
@@ -11582,68 +9442,6 @@
         {
             "apiversions": [],
             "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libbreakpadwrapper.so.0",
-                "/usr/lib/libcjson.so.1",
-                "/usr/lib/libdbus-1.so.3",
-                "/usr/lib/libds.so",
-                "/usr/lib/libdshalcli.so",
-                "/usr/lib/libgio-2.0.so.0",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libgobject-2.0.so.0",
-                "/usr/lib/libgthread-2.0.so.0",
-                "/usr/lib/liblibparodus.so",
-                "/usr/lib/libprocps.so.6",
-                "/usr/lib/librbus.so.0",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/libsafec-3.5.1.so.3",
-                "/usr/lib/libsoup-2.4.so.1",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtinyxml2.so.8",
-                "/usr/lib/libwdmp-c.so",
-                "/usr/lib/libwrp-c.so",
-                "/usr/lib/libyajl.so.2"
-            ],
-            "name": "/usr/lib/libparodusclient.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libbreakpadwrapper.so.0",
-                "/usr/lib/libcjson.so.1",
-                "/usr/lib/libdbus-1.so.3",
-                "/usr/lib/libds.so",
-                "/usr/lib/libdshalcli.so",
-                "/usr/lib/libgio-2.0.so.0",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libgobject-2.0.so.0",
-                "/usr/lib/libgthread-2.0.so.0",
-                "/usr/lib/liblibparodus.so",
-                "/usr/lib/libprocps.so.6",
-                "/usr/lib/librbus.so.0",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/libsafec-3.5.1.so.3",
-                "/usr/lib/libsoup-2.4.so.1",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtinyxml2.so.8",
-                "/usr/lib/libwdmp-c.so",
-                "/usr/lib/libwrp-c.so",
-                "/usr/lib/libyajl.so.2"
-            ],
-            "name": "/usr/lib/libparodusclient.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
                 "/lib/libc.so.6"
             ],
             "name": "/usr/lib/libpcap.so.1"
@@ -11654,44 +9452,6 @@
                 "/lib/libc.so.6"
             ],
             "name": "/usr/lib/libpcap.so.1.9.1"
-        },
-        {
-            "apiversions": [
-                "LIBPCI_3.0",
-                "LIBPCI_3.1",
-                "LIBPCI_3.2",
-                "LIBPCI_3.3",
-                "LIBPCI_3.4",
-                "LIBPCI_3.5",
-                "LIBPCI_3.6",
-                "LIBPCI_3.7"
-            ],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libresolv.so.2",
-                "/lib/libudev.so.1",
-                "/lib/libz.so.1"
-            ],
-            "name": "/usr/lib/libpci.so.3"
-        },
-        {
-            "apiversions": [
-                "LIBPCI_3.0",
-                "LIBPCI_3.1",
-                "LIBPCI_3.2",
-                "LIBPCI_3.3",
-                "LIBPCI_3.4",
-                "LIBPCI_3.5",
-                "LIBPCI_3.6",
-                "LIBPCI_3.7"
-            ],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libresolv.so.2",
-                "/lib/libudev.so.1",
-                "/lib/libz.so.1"
-            ],
-            "name": "/usr/lib/libpci.so.3.6.4"
         },
         {
             "apiversions": [],
@@ -11747,26 +9507,6 @@
                 "/usr/lib/libstdc++.so.6"
             ],
             "name": "/usr/lib/libperftool.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libm.so.6",
-                "/usr/lib/libcrypt.so.2"
-            ],
-            "name": "/usr/lib/libperl.so.5"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libm.so.6",
-                "/usr/lib/libcrypt.so.2"
-            ],
-            "name": "/usr/lib/libperl.so.5.30.0"
         },
         {
             "apiversions": [],
@@ -11827,30 +9567,6 @@
                 "/lib/libc.so.6"
             ],
             "name": "/usr/lib/libpopt.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/lib/librt.so.1",
-                "/usr/lib/libasound.so.2",
-                "/usr/lib/libjack.so.0"
-            ],
-            "name": "/usr/lib/libportaudio.so.2"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/lib/librt.so.1",
-                "/usr/lib/libasound.so.2",
-                "/usr/lib/libjack.so.0"
-            ],
-            "name": "/usr/lib/libportaudio.so.2.0.0"
         },
         {
             "apiversions": [],
@@ -11982,119 +9698,6 @@
             "apiversions": [],
             "deps": [
                 "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/lib/libutil.so.1"
-            ],
-            "name": "/usr/lib/libpython3.8.so.1.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libgobject-2.0.so.0",
-                "/usr/lib/libgstbase-1.0.so.0",
-                "/usr/lib/libgstreamer-1.0.so.0",
-                "/usr/lib/libinbsectionfilter.so.0",
-                "/usr/lib/libinbsimanager.so.0",
-                "/usr/lib/liblog4c.so.3",
-                "/usr/lib/liboobsectionfilter.so.0",
-                "/usr/lib/liboobsimgrstub.so.0",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/librfcapi.so.0",
-                "/usr/lib/libsectionfilter.so.0",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtinyxml.so.2.6.2"
-            ],
-            "name": "/usr/lib/libqamsrc.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libgobject-2.0.so.0",
-                "/usr/lib/libgstbase-1.0.so.0",
-                "/usr/lib/libgstreamer-1.0.so.0",
-                "/usr/lib/libinbsectionfilter.so.0",
-                "/usr/lib/libinbsimanager.so.0",
-                "/usr/lib/liblog4c.so.3",
-                "/usr/lib/liboobsectionfilter.so.0",
-                "/usr/lib/liboobsimgrstub.so.0",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/librfcapi.so.0",
-                "/usr/lib/libsectionfilter.so.0",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtinyxml.so.2.6.2"
-            ],
-            "name": "/usr/lib/libqamsrc.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libcurl.so.4",
-                "/usr/lib/librfcapi.so.0",
-                "/usr/lib/librmfosal.so.0",
-                "/usr/lib/librtCore.so",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/librbi.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libcurl.so.4",
-                "/usr/lib/librfcapi.so.0",
-                "/usr/lib/librmfosal.so.0",
-                "/usr/lib/librtCore.so",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/librbi.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/librfcapi.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/librbifilter.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/librfcapi.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/librbifilter.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
                 "/lib/libpthread.so.0",
                 "/usr/lib/librbuscore.so.0",
                 "/usr/lib/librtMessage.so.0"
@@ -12109,7 +9712,7 @@
                 "/usr/lib/librbuscore.so.0",
                 "/usr/lib/librtMessage.so.0"
             ],
-            "name": "/usr/lib/librbus.so.2.0.3"
+            "name": "/usr/lib/librbus.so.2.0.7"
         },
         {
             "apiversions": [],
@@ -12129,7 +9732,7 @@
                 "/usr/lib/libmsgpackc.so.2",
                 "/usr/lib/librtMessage.so.0"
             ],
-            "name": "/usr/lib/librbuscore.so.2.0.3"
+            "name": "/usr/lib/librbuscore.so.2.0.7"
         },
         {
             "apiversions": [],
@@ -12216,6 +9819,7 @@
                 "/lib/libgcc_s.so.1",
                 "/lib/libm.so.6",
                 "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgstapp-1.0.so.0",
                 "/usr/lib/libgstreamer-1.0.so.0",
                 "/usr/lib/libstdc++.so.6"
             ],
@@ -12244,28 +9848,6 @@
                 "/usr/lib/libstdc++.so.6"
             ],
             "name": "/usr/lib/librdkloggers.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/librdkloggerstub.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/librdkloggerstub.so.0.0.0"
         },
         {
             "apiversions": [],
@@ -12339,20 +9921,6 @@
                 "/lib/libc.so.6",
                 "/lib/libgcc_s.so.1",
                 "/lib/libm.so.6",
-                "/usr/lib/libWPEFrameworkCore.so.2",
-                "/usr/lib/libWPEFrameworkSecurityUtil.so.2",
-                "/usr/lib/libWPEFrameworkTracing.so.2",
-                "/usr/lib/libWPEFrameworkWebSocket.so.2",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/librdktv.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
                 "/usr/lib/libgio-2.0.so.0",
                 "/usr/lib/libglib-2.0.so.0",
                 "/usr/lib/libgobject-2.0.so.0",
@@ -12395,32 +9963,6 @@
             "apiversions": [],
             "deps": [
                 "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libz.so.1",
-                "/usr/lib/libcjson.so.1",
-                "/usr/lib/libcrypto.so.1.1",
-                "/usr/lib/libcurl.so.4",
-                "/usr/lib/libssl.so.1.1"
-            ],
-            "name": "/usr/lib/librdmopenssl.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libz.so.1",
-                "/usr/lib/libcjson.so.1",
-                "/usr/lib/libcrypto.so.1.1",
-                "/usr/lib/libcurl.so.4",
-                "/usr/lib/libssl.so.1.1"
-            ],
-            "name": "/usr/lib/librdmopenssl.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
                 "/lib/libtinfo.so.5"
             ],
             "name": "/usr/lib/libreadline.so.5"
@@ -12437,22 +9979,10 @@
             "apiversions": [],
             "deps": [
                 "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/librbifilter.so.0",
-                "/usr/lib/librfcapi.so.0",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtr181api.so.0"
-            ],
-            "name": "/usr/lib/librecorder.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
                 "/lib/libpthread.so.0",
                 "/usr/lib/libbreakpadwrapper.so.0",
                 "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcurl.so.4",
                 "/usr/lib/libprivilege.so.0",
                 "/usr/lib/libsecure_wrapper.so.0",
                 "/usr/lib/libstdc++.so.6"
@@ -12466,6 +9996,7 @@
                 "/lib/libpthread.so.0",
                 "/usr/lib/libbreakpadwrapper.so.0",
                 "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcurl.so.4",
                 "/usr/lib/libprivilege.so.0",
                 "/usr/lib/libsecure_wrapper.so.0",
                 "/usr/lib/libstdc++.so.6"
@@ -12479,6 +10010,7 @@
                 "/lib/libpthread.so.0",
                 "/usr/lib/libbreakpadwrapper.so.0",
                 "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcurl.so.4",
                 "/usr/lib/libprivilege.so.0",
                 "/usr/lib/libsecure_wrapper.so.0",
                 "/usr/lib/libstdc++.so.6"
@@ -12534,16 +10066,6 @@
                 "/usr/lib/libstdc++.so.6"
             ],
             "name": "/usr/lib/librfcapi.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [],
-            "name": "/usr/lib/librmfAudioCapture.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [],
-            "name": "/usr/lib/librmfAudioCapture.so.0.0.0"
         },
         {
             "apiversions": [],
@@ -12658,34 +10180,6 @@
             "name": "/usr/lib/librmfosalutils.so.0.0.0"
         },
         {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libjansson.so.4",
-                "/usr/lib/librfcapi.so.0",
-                "/usr/lib/librmfosal.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/librmfproxyservice.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libjansson.so.4",
-                "/usr/lib/librfcapi.so.0",
-                "/usr/lib/librmfosal.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/librmfproxyservice.so.0.0.0"
-        },
-        {
             "apiversions": [
                 "LIBRPCSERVER_1.0.0"
             ],
@@ -12791,7 +10285,7 @@
                 "/usr/lib/libcjson.so.1",
                 "/usr/lib/librdkloggers.so.0"
             ],
-            "name": "/usr/lib/librtMessage.so.2.0.3"
+            "name": "/usr/lib/librtMessage.so.2.0.7"
         },
         {
             "apiversions": [],
@@ -12817,28 +10311,6 @@
                 "/lib/libc.so.6"
             ],
             "name": "/usr/lib/libsafec-3.5.1.so.3.0.6"
-        },
-        {
-            "apiversions": [
-                "libsamplerate.so.0.0",
-                "libsamplerate.so.0.1"
-            ],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libm.so.6"
-            ],
-            "name": "/usr/lib/libsamplerate.so.0"
-        },
-        {
-            "apiversions": [
-                "libsamplerate.so.0.0",
-                "libsamplerate.so.0.1"
-            ],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libm.so.6"
-            ],
-            "name": "/usr/lib/libsamplerate.so.0.1.8"
         },
         {
             "apiversions": [
@@ -12869,8 +10341,10 @@
                 "/lib/libpthread.so.0",
                 "/usr/lib/libbreakpadwrapper.so.0",
                 "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librdkloggers.so.0",
                 "/usr/lib/libsecure_wrapper.so.0",
-                "/usr/lib/libstdc++.so.6"
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2utils.so.0"
             ],
             "name": "/usr/lib/libscheduler.so"
         },
@@ -12881,8 +10355,10 @@
                 "/lib/libpthread.so.0",
                 "/usr/lib/libbreakpadwrapper.so.0",
                 "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librdkloggers.so.0",
                 "/usr/lib/libsecure_wrapper.so.0",
-                "/usr/lib/libstdc++.so.6"
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2utils.so.0"
             ],
             "name": "/usr/lib/libscheduler.so.0"
         },
@@ -12893,8 +10369,10 @@
                 "/lib/libpthread.so.0",
                 "/usr/lib/libbreakpadwrapper.so.0",
                 "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librdkloggers.so.0",
                 "/usr/lib/libsecure_wrapper.so.0",
-                "/usr/lib/libstdc++.so.6"
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2utils.so.0"
             ],
             "name": "/usr/lib/libscheduler.so.0.0.0"
         },
@@ -12911,36 +10389,6 @@
                 "/lib/libc.so.6"
             ],
             "name": "/usr/lib/libseccomp.so.2.4.3"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libinbsectionfilter.so.0",
-                "/usr/lib/liboobsectionfilter.so.0",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/librfcapi.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libsectionfilter.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libinbsectionfilter.so.0",
-                "/usr/lib/liboobsectionfilter.so.0",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/librfcapi.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libsectionfilter.so.0.0.0"
         },
         {
             "apiversions": [],
@@ -13002,87 +10450,6 @@
                 "/usr/lib/libstdc++.so.6"
             ],
             "name": "/usr/lib/libsecurityagent.so.2.1.11"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libBTMgr.so.0",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libQt5Gui.so.5",
-                "/usr/lib/libQt5Network.so.5",
-                "/usr/lib/libcjson.so.1",
-                "/usr/lib/libcrypto.so.1.1",
-                "/usr/lib/libcurl.so.4",
-                "/usr/lib/libds.so",
-                "/usr/lib/librdkstmgr.so.2",
-                "/usr/lib/librfcapi.so.0",
-                "/usr/lib/librtCore.so",
-                "/usr/lib/librtRemote.so",
-                "/usr/lib/libsafec-3.5.1.so.3",
-                "/usr/lib/libsecure_wrapper.so.0",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtr181api.so.0",
-                "/usr/lib/libyajl.so.2"
-            ],
-            "name": "/usr/lib/libservicemanager.so.1"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libBTMgr.so.0",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libQt5Gui.so.5",
-                "/usr/lib/libQt5Network.so.5",
-                "/usr/lib/libcjson.so.1",
-                "/usr/lib/libcrypto.so.1.1",
-                "/usr/lib/libcurl.so.4",
-                "/usr/lib/libds.so",
-                "/usr/lib/librdkstmgr.so.2",
-                "/usr/lib/librfcapi.so.0",
-                "/usr/lib/librtCore.so",
-                "/usr/lib/librtRemote.so",
-                "/usr/lib/libsafec-3.5.1.so.3",
-                "/usr/lib/libsecure_wrapper.so.0",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtr181api.so.0",
-                "/usr/lib/libyajl.so.2"
-            ],
-            "name": "/usr/lib/libservicemanager.so.1.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libBTMgr.so.0",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libQt5Gui.so.5",
-                "/usr/lib/libQt5Network.so.5",
-                "/usr/lib/libcjson.so.1",
-                "/usr/lib/libcrypto.so.1.1",
-                "/usr/lib/libcurl.so.4",
-                "/usr/lib/libds.so",
-                "/usr/lib/librdkstmgr.so.2",
-                "/usr/lib/librfcapi.so.0",
-                "/usr/lib/librtCore.so",
-                "/usr/lib/librtRemote.so",
-                "/usr/lib/libsafec-3.5.1.so.3",
-                "/usr/lib/libsecure_wrapper.so.0",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtr181api.so.0",
-                "/usr/lib/libyajl.so.2"
-            ],
-            "name": "/usr/lib/libservicemanager.so.1.0.0"
         },
         {
             "apiversions": [],
@@ -13153,7 +10520,6 @@
                 "/usr/lib/libdvrsink.so.0",
                 "/usr/lib/libglib-2.0.so.0",
                 "/usr/lib/libhnsource.so.0",
-                "/usr/lib/libqamsrc.so.0",
                 "/usr/lib/librfcapi.so.0",
                 "/usr/lib/libsafec-3.5.1.so.3",
                 "/usr/lib/libstdc++.so.6",
@@ -13176,7 +10542,6 @@
                 "/usr/lib/libdvrsink.so.0",
                 "/usr/lib/libglib-2.0.so.0",
                 "/usr/lib/libhnsource.so.0",
-                "/usr/lib/libqamsrc.so.0",
                 "/usr/lib/librfcapi.so.0",
                 "/usr/lib/libsafec-3.5.1.so.3",
                 "/usr/lib/libstdc++.so.6",
@@ -13211,95 +10576,6 @@
                 "/usr/lib/libvorbisenc.so.2"
             ],
             "name": "/usr/lib/libsndfile.so.1.0.28"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/lib/librt.so.1",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libcjson.so.1",
-                "/usr/lib/libcrypto.so.1.1",
-                "/usr/lib/libnetsnmp.so.35",
-                "/usr/lib/libnetsnmpagent.so.35",
-                "/usr/lib/libnetsnmphelpers.so.35",
-                "/usr/lib/libnetsnmpmibs.so.35",
-                "/usr/lib/libsafec-3.5.1.so.3",
-                "/usr/lib/libssl.so.1.1",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libsnmp_ipdvr.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/lib/librt.so.1",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libcjson.so.1",
-                "/usr/lib/libcrypto.so.1.1",
-                "/usr/lib/libnetsnmp.so.35",
-                "/usr/lib/libnetsnmpagent.so.35",
-                "/usr/lib/libnetsnmphelpers.so.35",
-                "/usr/lib/libnetsnmpmibs.so.35",
-                "/usr/lib/libsafec-3.5.1.so.3",
-                "/usr/lib/libssl.so.1.1",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libsnmp_ipdvr.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libsnmpstub.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libsnmpstub.so.0.0.0"
-        },
-        {
-            "apiversions": [
-                "SOLV_1.0",
-                "SOLV_1.1",
-                "SOLV_1.2",
-                "SOLV_1.3"
-            ],
-            "deps": [
-                "/lib/libc.so.6"
-            ],
-            "name": "/usr/lib/libsolv.so.1"
-        },
-        {
-            "apiversions": [],
-            "deps": [],
-            "name": "/usr/lib/libsoundplayer.so.1"
-        },
-        {
-            "apiversions": [],
-            "deps": [],
-            "name": "/usr/lib/libsoundplayer.so.1.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [],
-            "name": "/usr/lib/libsoundplayer.so.1.0.0"
         },
         {
             "apiversions": [],
@@ -13491,22 +10767,6 @@
             "apiversions": [],
             "deps": [
                 "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libgcc_s.so.1",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libboost_chrono.so.1.72.0",
-                "/usr/lib/libboost_filesystem.so.1.72.0",
-                "/usr/lib/libboost_thread.so.1.72.0",
-                "/usr/lib/libfuse.so.2",
-                "/usr/lib/libglog.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libstreamlink.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
                 "/lib/libgcc_s.so.1",
                 "/lib/libpthread.so.0",
                 "/usr/lib/libstdc++.so.6"
@@ -13514,304 +10774,52 @@
             "name": "/usr/lib/libsubtec.so"
         },
         {
-            "apiversions": [],
-            "deps": [
-                "/lib/ld-linux-armhf.so.3",
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libsubttxrend-gfx.so.0",
-                "/usr/lib/libsubttxrend-protocol.so.0"
+            "apiversions": [
+                "LIBSWRESAMPLE_3"
             ],
-            "name": "/usr/lib/libsubttxrend-cc.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/ld-linux-armhf.so.3",
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libsubttxrend-gfx.so.0",
-                "/usr/lib/libsubttxrend-protocol.so.0"
-            ],
-            "name": "/usr/lib/libsubttxrend-cc.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/ld-linux-armhf.so.3",
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libsubttxrend-common.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/ld-linux-armhf.so.3",
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libsubttxrend-common.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/ld-linux-armhf.so.3",
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libgio-2.0.so.0",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libgobject-2.0.so.0",
-                "/usr/lib/libjansson.so.4",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libsubttxrend-dbus.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/ld-linux-armhf.so.3",
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libgio-2.0.so.0",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libgobject-2.0.so.0",
-                "/usr/lib/libjansson.so.4",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libsubttxrend-dbus.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libdvbsubdecoder.so.0",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libsubttxrend-gfx.so.0"
-            ],
-            "name": "/usr/lib/libsubttxrend-dvbsub.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libdvbsubdecoder.so.0",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libsubttxrend-gfx.so.0"
-            ],
-            "name": "/usr/lib/libsubttxrend-dvbsub.so.0.0.0"
-        },
-        {
-            "apiversions": [],
             "deps": [
                 "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
                 "/lib/libm.so.6",
                 "/lib/libpthread.so.0",
-                "/usr/lib/libfontconfig.so.1",
-                "/usr/lib/libfreetype.so.6",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libharfbuzz.so.0",
-                "/usr/lib/libpng16.so.16",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libsubttxrend-common.so.0",
-                "/usr/lib/libwayland-client.so.0",
-                "/usr/lib/libxkbcommon.so.0"
+                "/usr/lib/libavutil.so.56"
             ],
-            "name": "/usr/lib/libsubttxrend-gfx.so.0"
+            "name": "/usr/lib/libswresample.so.3"
         },
         {
-            "apiversions": [],
+            "apiversions": [
+                "LIBSWRESAMPLE_3"
+            ],
             "deps": [
                 "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
                 "/lib/libm.so.6",
                 "/lib/libpthread.so.0",
-                "/usr/lib/libfontconfig.so.1",
-                "/usr/lib/libfreetype.so.6",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libharfbuzz.so.0",
-                "/usr/lib/libpng16.so.16",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libsubttxrend-common.so.0",
-                "/usr/lib/libwayland-client.so.0",
-                "/usr/lib/libxkbcommon.so.0"
+                "/usr/lib/libavutil.so.56"
             ],
-            "name": "/usr/lib/libsubttxrend-gfx.so.0.0.0"
+            "name": "/usr/lib/libswresample.so.3.5.100"
         },
         {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libsubttxrend-common.so.0"
+            "apiversions": [
+                "LIBSWSCALE_5"
             ],
-            "name": "/usr/lib/libsubttxrend-protocol.so.0"
-        },
-        {
-            "apiversions": [],
             "deps": [
                 "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libsubttxrend-common.so.0"
-            ],
-            "name": "/usr/lib/libsubttxrend-protocol.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/ld-linux-armhf.so.3",
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libz.so.1",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libsubttxrend-gfx.so.0",
-                "/usr/lib/libsubttxrend-protocol.so.0"
-            ],
-            "name": "/usr/lib/libsubttxrend-scte.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/ld-linux-armhf.so.3",
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libz.so.1",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libsubttxrend-gfx.so.0",
-                "/usr/lib/libsubttxrend-protocol.so.0"
-            ],
-            "name": "/usr/lib/libsubttxrend-scte.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/ld-linux-armhf.so.3",
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libsubttxrend-protocol.so.0"
-            ],
-            "name": "/usr/lib/libsubttxrend-socksrc.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/ld-linux-armhf.so.3",
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libsubttxrend-protocol.so.0"
-            ],
-            "name": "/usr/lib/libsubttxrend-socksrc.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
                 "/lib/libm.so.6",
                 "/lib/libpthread.so.0",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libsubttxrend-common.so.0",
-                "/usr/lib/libsubttxrend-gfx.so.0",
-                "/usr/lib/libxml2.so.2"
+                "/usr/lib/libavutil.so.56"
             ],
-            "name": "/usr/lib/libsubttxrend-ttml.so.0"
+            "name": "/usr/lib/libswscale.so.5"
         },
         {
-            "apiversions": [],
+            "apiversions": [
+                "LIBSWSCALE_5"
+            ],
             "deps": [
                 "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
                 "/lib/libm.so.6",
                 "/lib/libpthread.so.0",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libsubttxrend-common.so.0",
-                "/usr/lib/libsubttxrend-gfx.so.0",
-                "/usr/lib/libxml2.so.2"
+                "/usr/lib/libavutil.so.56"
             ],
-            "name": "/usr/lib/libsubttxrend-ttml.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libsubttxrend-common.so.0",
-                "/usr/lib/libsubttxrend-gfx.so.0",
-                "/usr/lib/libttxdecoder.so.0"
-            ],
-            "name": "/usr/lib/libsubttxrend-ttxt.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libsubttxrend-common.so.0",
-                "/usr/lib/libsubttxrend-gfx.so.0",
-                "/usr/lib/libttxdecoder.so.0"
-            ],
-            "name": "/usr/lib/libsubttxrend-ttxt.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libsubttxrend-common.so.0",
-                "/usr/lib/libsubttxrend-gfx.so.0"
-            ],
-            "name": "/usr/lib/libsubttxrend-webvtt.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libsubttxrend-common.so.0",
-                "/usr/lib/libsubttxrend-gfx.so.0"
-            ],
-            "name": "/usr/lib/libsubttxrend-webvtt.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libsystemutilstub.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libsystemutilstub.so.0.0.0"
+            "name": "/usr/lib/libswscale.so.5.5.100"
         },
         {
             "apiversions": [],
@@ -14142,190 +11150,6 @@
             "apiversions": [],
             "deps": [
                 "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libgobject-2.0.so.0",
-                "/usr/lib/libgstbase-1.0.so.0",
-                "/usr/lib/libgstreamer-1.0.so.0",
-                "/usr/lib/librfcapi.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libtranscoderfilter.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libgobject-2.0.so.0",
-                "/usr/lib/libgstbase-1.0.so.0",
-                "/usr/lib/libgstreamer-1.0.so.0",
-                "/usr/lib/librfcapi.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libtranscoderfilter.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtrm.so.0"
-            ],
-            "name": "/usr/lib/libtrh.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtrm.so.0"
-            ],
-            "name": "/usr/lib/libtrh.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libuuid.so.1",
-                "/usr/lib/libjansson.so.4",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/libsafec-3.5.1.so.3",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libtrm.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libuuid.so.1",
-                "/usr/lib/libjansson.so.4",
-                "/usr/lib/librdkloggers.so.0",
-                "/usr/lib/libsafec-3.5.1.so.3",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libtrm.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/lib/libuuid.so.1",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libdbus-1.so.3",
-                "/usr/lib/libdirect-1.7.so.7",
-                "/usr/lib/libdirectfb-1.7.so.7",
-                "/usr/lib/libds.so",
-                "/usr/lib/libdshalcli.so",
-                "/usr/lib/libfusion-1.7.so.7",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libgthread-2.0.so.0",
-                "/usr/lib/libjansson.so.4",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtrm.so.0"
-            ],
-            "name": "/usr/lib/libtrmdiaginfo.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/lib/libuuid.so.1",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libdbus-1.so.3",
-                "/usr/lib/libdirect-1.7.so.7",
-                "/usr/lib/libdirectfb-1.7.so.7",
-                "/usr/lib/libds.so",
-                "/usr/lib/libdshalcli.so",
-                "/usr/lib/libfusion-1.7.so.7",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libgthread-2.0.so.0",
-                "/usr/lib/libjansson.so.4",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtrm.so.0"
-            ],
-            "name": "/usr/lib/libtrmdiaginfo.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtrm.so.0"
-            ],
-            "name": "/usr/lib/libtrmstub.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtrm.so.0"
-            ],
-            "name": "/usr/lib/libtrmstub.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [],
-            "name": "/usr/lib/libtrower-base64.so.1.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/ld-linux-armhf.so.3",
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libttxdecoder.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/ld-linux-armhf.so.3",
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libttxdecoder.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6"
-            ],
-            "name": "/usr/lib/libucresolv.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
                 "/lib/libdl.so.2",
                 "/lib/libgcc_s.so.1",
                 "/lib/libpthread.so.0",
@@ -14387,112 +11211,6 @@
                 "/usr/lib/libyajl.so.2"
             ],
             "name": "/usr/lib/libuinput.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libpthread.so.0"
-            ],
-            "name": "/usr/lib/libulockmgr.so.1"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libpthread.so.0"
-            ],
-            "name": "/usr/lib/libulockmgr.so.1.0.1"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/ld-linux-armhf.so.3",
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libunwind.so.8"
-            ],
-            "name": "/usr/lib/libunwind-arm.so.8"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/ld-linux-armhf.so.3",
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libunwind.so.8"
-            ],
-            "name": "/usr/lib/libunwind-arm.so.8.0.1"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1"
-            ],
-            "name": "/usr/lib/libunwind-coredump.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1"
-            ],
-            "name": "/usr/lib/libunwind-coredump.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1"
-            ],
-            "name": "/usr/lib/libunwind-ptrace.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1"
-            ],
-            "name": "/usr/lib/libunwind-ptrace.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libunwind-arm.so.8",
-                "/usr/lib/libunwind.so.8"
-            ],
-            "name": "/usr/lib/libunwind-setjmp.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libunwind-arm.so.8",
-                "/usr/lib/libunwind.so.8"
-            ],
-            "name": "/usr/lib/libunwind-setjmp.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/ld-linux-armhf.so.3",
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1"
-            ],
-            "name": "/usr/lib/libunwind.so.8"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/ld-linux-armhf.so.3",
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1"
-            ],
-            "name": "/usr/lib/libunwind.so.8.0.1"
         },
         {
             "apiversions": [],
@@ -14718,6 +11436,7 @@
             "deps": [
                 "/lib/libc.so.6",
                 "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
                 "/usr/lib/libwebp.so.6"
             ],
             "name": "/usr/lib/libwebpdemux.so.2"
@@ -14727,6 +11446,7 @@
             "deps": [
                 "/lib/libc.so.6",
                 "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
                 "/usr/lib/libwebp.so.6"
             ],
             "name": "/usr/lib/libwebpdemux.so.2.0.0"
@@ -15017,44 +11737,6 @@
             "apiversions": [],
             "deps": [
                 "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libwesteros_gl.so.0"
-            ],
-            "name": "/usr/lib/libwesteroshalstub.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libwesteros_gl.so.0"
-            ],
-            "name": "/usr/lib/libwesteroshalstub.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libwpa_client.so"
-            ],
-            "name": "/usr/lib/libwifihal.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libwpa_client.so"
-            ],
-            "name": "/usr/lib/libwifihal.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
                 "/usr/lib/libbreakpadwrapper.so.0"
             ],
             "name": "/usr/lib/libwpa_client.so"
@@ -15078,16 +11760,6 @@
                 "/usr/lib/libxkbcommon.so.0"
             ],
             "name": "/usr/lib/libwpe-1.0.so.1.8.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libcimplog.so.1.0.0",
-                "/usr/lib/libmsgpackc.so.2",
-                "/usr/lib/libtrower-base64.so.1.0.0"
-            ],
-            "name": "/usr/lib/libwrp-c.so"
         },
         {
             "apiversions": [],
@@ -15335,20 +12007,6 @@
         {
             "apiversions": [],
             "deps": [
-                "/usr/lib/librdkx-logger.so.0"
-            ],
-            "name": "/usr/lib/libxr_atomic.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/usr/lib/librdkx-logger.so.0"
-            ],
-            "name": "/usr/lib/libxr_atomic.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
                 "/lib/libc.so.6",
                 "/usr/lib/librdkx-logger.so.0"
             ],
@@ -15416,28 +12074,6 @@
             "apiversions": [],
             "deps": [
                 "/lib/libc.so.6",
-                "/lib/librt.so.1",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/librdkx-logger.so.0",
-                "/usr/lib/libxraudio.so.0"
-            ],
-            "name": "/usr/lib/libxraudio-utils.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/librt.so.1",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/librdkx-logger.so.0",
-                "/usr/lib/libxraudio.so.0"
-            ],
-            "name": "/usr/lib/libxraudio-utils.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
                 "/lib/libm.so.6",
                 "/lib/libpthread.so.0",
                 "/usr/lib/libbsd.so.0",
@@ -15495,7 +12131,6 @@
                 "/lib/libc.so.6",
                 "/lib/libpthread.so.0",
                 "/usr/lib/libbsd.so.0",
-                "/usr/lib/libcurl.so.4",
                 "/usr/lib/libnopoll.so.0",
                 "/usr/lib/librdkx-logger.so.0",
                 "/usr/lib/libsafec-3.5.1.so.3",
@@ -15513,7 +12148,6 @@
                 "/lib/libc.so.6",
                 "/lib/libpthread.so.0",
                 "/usr/lib/libbsd.so.0",
-                "/usr/lib/libcurl.so.4",
                 "/usr/lib/libnopoll.so.0",
                 "/usr/lib/librdkx-logger.so.0",
                 "/usr/lib/libsafec-3.5.1.so.3",
@@ -15639,26 +12273,6 @@
         {
             "apiversions": [],
             "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libxupnpstub.so.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/libxupnpstub.so.0.0.0"
-        },
-        {
-            "apiversions": [],
-            "deps": [
                 "/lib/libc.so.6"
             ],
             "name": "/usr/lib/libyajl.so.2"
@@ -15675,492 +12289,14 @@
             "deps": [
                 "/lib/libc.so.6"
             ],
-            "name": "/usr/lib/libyaml-0.so.2"
+            "name": "/usr/lib/libzstd.so.1"
         },
         {
             "apiversions": [],
             "deps": [
                 "/lib/libc.so.6"
             ],
-            "name": "/usr/lib/libyaml-0.so.2.0.6"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/accent.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libudev.so.1",
-                "/usr/lib/libasound.so.2",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/alsa_usb.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/lib/libusb-0.1.so.4",
-                "/lib/libusb-1.0.so.0",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/atilibusb.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/atwf83.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/lib/libutil.so.1",
-                "/usr/lib/liblirc_driver.so.0",
-                "/usr/lib/libportaudio.so.2"
-            ],
-            "name": "/usr/lib/lirc/plugins/audio.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/libasound.so.2",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/audio_alsa.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/lib/libusb-0.1.so.4",
-                "/lib/libusb-1.0.so.0",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/awlibusb.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/bte.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/lib/libusb-0.1.so.4",
-                "/lib/libusb-1.0.so.0",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/commandir.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/creative.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/creative_infracd.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/default.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/devinput.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/lib/libusb-0.1.so.4",
-                "/lib/libusb-1.0.so.0",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/dfclibusb.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/dsp.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/ea65.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/file.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/lib/libusb-1.0.so.0",
-                "/usr/lib/libftdi1.so.2",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/ftdi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/lib/libusb-1.0.so.0",
-                "/usr/lib/libftdi1.so.2",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/ftdix.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/girs.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/hiddev.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/i2cuser.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/irlink.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/irtoy.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/livedrive_midi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/livedrive_seq.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/logitech.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/mouseremote.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/mp3anywhere.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/mplay.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/pcmak.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/pinsys.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/pixelview.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/silitek.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/slinke.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/lib/libusb-0.1.so.4",
-                "/lib/libusb-1.0.so.0",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/srm7500libusb.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/tira.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/udp.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/uirt2.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/uirt2_raw.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/usbx.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/liblirc_driver.so.0"
-            ],
-            "name": "/usr/lib/lirc/plugins/zotac.so"
+            "name": "/usr/lib/libzstd.so.1.4.5"
         },
         {
             "apiversions": [],
@@ -16327,13 +12463,6 @@
         {
             "apiversions": [],
             "deps": [
-                "/lib/libc.so.6"
-            ],
-            "name": "/usr/lib/perl5/5.30.1/arm-linux/auto/mro/mro.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
                 "/lib/libc.so.6",
                 "/lib/libgcc_s.so.1",
                 "/usr/lib/libstdc++.so.6"
@@ -16399,6 +12528,16 @@
                 "/usr/lib/libstdc++.so.6"
             ],
             "name": "/usr/lib/plugins/dobby/libStoragePlugin.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libsecurityagent.so.2",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/plugins/dobby/libThunderPlugin.so.1"
         },
         {
             "apiversions": [],
@@ -16702,475 +12841,6 @@
         },
         {
             "apiversions": [],
-            "deps": [],
-            "name": "/usr/lib/python3.8/lib-dynload/_bisect.cpython-38-arm-linux-gnueabi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6"
-            ],
-            "name": "/usr/lib/python3.8/lib-dynload/_blake2.cpython-38-arm-linux-gnueabi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libbz2.so.1"
-            ],
-            "name": "/usr/lib/python3.8/lib-dynload/_bz2.cpython-38-arm-linux-gnueabi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libcrypt.so.2"
-            ],
-            "name": "/usr/lib/python3.8/lib-dynload/_crypt.cpython-38-arm-linux-gnueabi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [],
-            "name": "/usr/lib/python3.8/lib-dynload/_csv.cpython-38-arm-linux-gnueabi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libm.so.6"
-            ],
-            "name": "/usr/lib/python3.8/lib-dynload/_datetime.cpython-38-arm-linux-gnueabi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libcrypto.so.1.1"
-            ],
-            "name": "/usr/lib/python3.8/lib-dynload/_hashlib.cpython-38-arm-linux-gnueabi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [],
-            "name": "/usr/lib/python3.8/lib-dynload/_heapq.cpython-38-arm-linux-gnueabi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/liblzma.so.5"
-            ],
-            "name": "/usr/lib/python3.8/lib-dynload/_lzma.cpython-38-arm-linux-gnueabi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6"
-            ],
-            "name": "/usr/lib/python3.8/lib-dynload/_md5.cpython-38-arm-linux-gnueabi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [],
-            "name": "/usr/lib/python3.8/lib-dynload/_opcode.cpython-38-arm-linux-gnueabi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6"
-            ],
-            "name": "/usr/lib/python3.8/lib-dynload/_posixsubprocess.cpython-38-arm-linux-gnueabi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6"
-            ],
-            "name": "/usr/lib/python3.8/lib-dynload/_random.cpython-38-arm-linux-gnueabi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6"
-            ],
-            "name": "/usr/lib/python3.8/lib-dynload/_sha1.cpython-38-arm-linux-gnueabi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6"
-            ],
-            "name": "/usr/lib/python3.8/lib-dynload/_sha256.cpython-38-arm-linux-gnueabi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6"
-            ],
-            "name": "/usr/lib/python3.8/lib-dynload/_sha3.cpython-38-arm-linux-gnueabi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6"
-            ],
-            "name": "/usr/lib/python3.8/lib-dynload/_sha512.cpython-38-arm-linux-gnueabi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6"
-            ],
-            "name": "/usr/lib/python3.8/lib-dynload/_socket.cpython-38-arm-linux-gnueabi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libcrypto.so.1.1",
-                "/usr/lib/libssl.so.1.1"
-            ],
-            "name": "/usr/lib/python3.8/lib-dynload/_ssl.cpython-38-arm-linux-gnueabi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6"
-            ],
-            "name": "/usr/lib/python3.8/lib-dynload/_struct.cpython-38-arm-linux-gnueabi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libuuid.so.1"
-            ],
-            "name": "/usr/lib/python3.8/lib-dynload/_uuid.cpython-38-arm-linux-gnueabi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6"
-            ],
-            "name": "/usr/lib/python3.8/lib-dynload/array.cpython-38-arm-linux-gnueabi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libz.so.1"
-            ],
-            "name": "/usr/lib/python3.8/lib-dynload/binascii.cpython-38-arm-linux-gnueabi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libm.so.6"
-            ],
-            "name": "/usr/lib/python3.8/lib-dynload/cmath.cpython-38-arm-linux-gnueabi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6"
-            ],
-            "name": "/usr/lib/python3.8/lib-dynload/grp.cpython-38-arm-linux-gnueabi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libm.so.6"
-            ],
-            "name": "/usr/lib/python3.8/lib-dynload/math.cpython-38-arm-linux-gnueabi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6"
-            ],
-            "name": "/usr/lib/python3.8/lib-dynload/parser.cpython-38-arm-linux-gnueabi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libreadline.so.5"
-            ],
-            "name": "/usr/lib/python3.8/lib-dynload/readline.cpython-38-arm-linux-gnueabi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6"
-            ],
-            "name": "/usr/lib/python3.8/lib-dynload/select.cpython-38-arm-linux-gnueabi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6"
-            ],
-            "name": "/usr/lib/python3.8/lib-dynload/termios.cpython-38-arm-linux-gnueabi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6"
-            ],
-            "name": "/usr/lib/python3.8/lib-dynload/unicodedata.cpython-38-arm-linux-gnueabi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libz.so.1"
-            ],
-            "name": "/usr/lib/python3.8/lib-dynload/zlib.cpython-38-arm-linux-gnueabi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libyaml-0.so.2"
-            ],
-            "name": "/usr/lib/python3.8/site-packages/_yaml.cpython-38-arm-linux-gnueabi.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libQt5Network.so.5",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/qt5/plugins/bearer/libqgenericbearer.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libQt5Gui.so.5",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/qt5/plugins/generic/libqevdevkeyboardplugin.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libQt5Gui.so.5",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/qt5/plugins/generic/libqevdevmouseplugin.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libQt5Gui.so.5",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/qt5/plugins/generic/libqevdevtabletplugin.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libQt5Gui.so.5",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/qt5/plugins/generic/libqevdevtouchplugin.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libQt5Gui.so.5",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/qt5/plugins/imageformats/libqgif.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libQt5Gui.so.5",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/qt5/plugins/imageformats/libqico.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libQt5Gui.so.5",
-                "/usr/lib/libjpeg.so.62",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/qt5/plugins/imageformats/libqjpeg.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libQt5Gui.so.5",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libxkbcommon.so.0"
-            ],
-            "name": "/usr/lib/qt5/plugins/platforminputcontexts/libcomposeplatforminputcontextplugin.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libm.so.6",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libQt5Gui.so.5",
-                "/usr/lib/libdirectfb-1.7.so.7",
-                "/usr/lib/libfontconfig.so.1",
-                "/usr/lib/libfreetype.so.6",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/qt5/plugins/platforms/libqdirectfb.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/libEGL.so.1",
-                "/usr/lib/libGLESv2.so.2",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libQt5Gui.so.5",
-                "/usr/lib/libfontconfig.so.1",
-                "/usr/lib/libfreetype.so.6",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/qt5/plugins/platforms/libqeglfs.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/lib/libudev.so.1",
-                "/usr/lib/libEGL.so.1",
-                "/usr/lib/libGLESv2.so.2",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libQt5Gui.so.5",
-                "/usr/lib/libdrm.so.2",
-                "/usr/lib/libfontconfig.so.1",
-                "/usr/lib/libfreetype.so.6",
-                "/usr/lib/libgbm.so.1",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/qt5/plugins/platforms/libqkms.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libQt5Gui.so.5",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/qt5/plugins/platforms/libqminimal.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libm.so.6",
-                "/usr/lib/libEGL.so.1",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libQt5Gui.so.5",
-                "/usr/lib/libfontconfig.so.1",
-                "/usr/lib/libfreetype.so.6",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/qt5/plugins/platforms/libqminimalegl.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libm.so.6",
-                "/usr/lib/libQt5Core.so.5",
-                "/usr/lib/libQt5Gui.so.5",
-                "/usr/lib/libfreetype.so.6",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/qt5/plugins/platforms/libqoffscreen.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libm.so.6",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libboost_regex.so.1.72.0",
-                "/usr/lib/libbuqu.so",
-                "/usr/lib/libcurl.so.4",
-                "/usr/lib/libglog.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/streamfs/libfcc_lib.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libpthread.so.0",
-                "/usr/lib/libcurl.so.4",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/streamfs/libsampleplugin.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libdl.so.2",
-                "/lib/libsystemd.so.0",
-                "/lib/libutil.so.1",
-                "/lib/libwrap.so.0",
-                "/usr/lib/libnsl.so.2"
-            ],
-            "name": "/usr/lib/stunnel/libstunnel.so"
-        },
-        {
-            "apiversions": [],
             "deps": [
                 "/usr/lib/libWPEWebKit-1.0.so.3"
             ],
@@ -17202,81 +12872,6 @@
             "deps": [
                 "/lib/libc.so.6",
                 "/lib/libgcc_s.so.1",
-                "/usr/lib/libBTMgr.so.0",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libWPEFrameworkCore.so.2",
-                "/usr/lib/libWPEFrameworkPlugins.so.2",
-                "/usr/lib/libWPEFrameworkTracing.so.2",
-                "/usr/lib/libbreakpadwrapper.so.0",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtelemetry_msgsender.so.0"
-            ],
-            "name": "/usr/lib/wpeframework/plugins/libWPEFrameworkBluetooth.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libWPEFrameworkCore.so.2",
-                "/usr/lib/libWPEFrameworkDefinitions.so.2",
-                "/usr/lib/libWPEFrameworkPlugins.so.2",
-                "/usr/lib/libWPEFrameworkTracing.so.2",
-                "/usr/lib/libbreakpadwrapper.so.0",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/wpeframework/plugins/libWPEFrameworkCobalt.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libWPEFrameworkCore.so.2",
-                "/usr/lib/libWPEFrameworkTracing.so.2",
-                "/usr/lib/libbreakpadwrapper.so.0",
-                "/usr/lib/libcobalt.so",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/wpeframework/plugins/libWPEFrameworkCobaltImpl.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libWPEFrameworkCore.so.2",
-                "/usr/lib/libWPEFrameworkPlugins.so.2",
-                "/usr/lib/libWPEFrameworkTracing.so.2",
-                "/usr/lib/libbreakpadwrapper.so.0",
-                "/usr/lib/libcrypto.so.1.1",
-                "/usr/lib/librfcapi.so.0",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtelemetry_msgsender.so.0",
-                "/usr/lib/libtrower-base64.so.1.0.0"
-            ],
-            "name": "/usr/lib/wpeframework/plugins/libWPEFrameworkContinueWatching.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libWPEFrameworkCore.so.2",
-                "/usr/lib/libWPEFrameworkPlugins.so.2",
-                "/usr/lib/libWPEFrameworkTracing.so.2",
-                "/usr/lib/libbreakpadwrapper.so.0",
-                "/usr/lib/libcurl.so.4",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtelemetry_msgsender.so.0"
-            ],
-            "name": "/usr/lib/wpeframework/plugins/libWPEFrameworkDeviceDiagnostics.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
                 "/usr/lib/libIARMBus.so.0",
                 "/usr/lib/libWPEFrameworkCore.so.2",
                 "/usr/lib/libWPEFrameworkDefinitions.so.2",
@@ -17295,65 +12890,17 @@
             "deps": [
                 "/lib/libc.so.6",
                 "/lib/libgcc_s.so.1",
-                "/usr/lib/libIARMBus.so.0",
                 "/usr/lib/libWPEFrameworkCore.so.2",
                 "/usr/lib/libWPEFrameworkPlugins.so.2",
-                "/usr/lib/libWPEFrameworkProtocols.so.2",
                 "/usr/lib/libWPEFrameworkTracing.so.2",
+                "/usr/lib/libaamp.so",
                 "/usr/lib/libbreakpadwrapper.so.0",
-                "/usr/lib/libds.so",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgstreamer-1.0.so.0",
                 "/usr/lib/libstdc++.so.6",
                 "/usr/lib/libtelemetry_msgsender.so.0"
             ],
-            "name": "/usr/lib/wpeframework/plugins/libWPEFrameworkDisplaySettings.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libWPEFrameworkCore.so.2",
-                "/usr/lib/libWPEFrameworkCryptalgo.so.2",
-                "/usr/lib/libWPEFrameworkDefinitions.so.2",
-                "/usr/lib/libWPEFrameworkPlugins.so.2",
-                "/usr/lib/libWPEFrameworkProtocols.so.2",
-                "/usr/lib/libWPEFrameworkTracing.so.2",
-                "/usr/lib/libfwupgrade-lib.so.1",
-                "/usr/lib/libstdc++.so.6"
-            ],
-            "name": "/usr/lib/wpeframework/plugins/libWPEFrameworkFirmwareControl.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libWPEFrameworkCore.so.2",
-                "/usr/lib/libWPEFrameworkPlugins.so.2",
-                "/usr/lib/libWPEFrameworkTracing.so.2",
-                "/usr/lib/libbreakpadwrapper.so.0",
-                "/usr/lib/libds.so",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtelemetry_msgsender.so.0"
-            ],
-            "name": "/usr/lib/wpeframework/plugins/libWPEFrameworkFrameRate.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libWPEFrameworkCore.so.2",
-                "/usr/lib/libWPEFrameworkPlugins.so.2",
-                "/usr/lib/libWPEFrameworkTracing.so.2",
-                "/usr/lib/libbreakpadwrapper.so.0",
-                "/usr/lib/libds.so",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtelemetry_msgsender.so.0"
-            ],
-            "name": "/usr/lib/wpeframework/plugins/libWPEFrameworkHdcpProfile.so"
+            "name": "/usr/lib/wpeframework/plugins/libWPEFrameworkFireboltMediaPlayer.so"
         },
         {
             "apiversions": [],
@@ -17380,7 +12927,7 @@
                 "/usr/lib/libWPEFrameworkCore.so.2",
                 "/usr/lib/libWPEFrameworkPlugins.so.2",
                 "/usr/lib/libWPEFrameworkTracing.so.2",
-                "/usr/lib/libarchive.so.13",
+                "/usr/lib/libarchive.so.19",
                 "/usr/lib/libboost_filesystem.so.1.72.0",
                 "/usr/lib/libcurl.so.4",
                 "/usr/lib/libsqlite3.so.0",
@@ -17409,37 +12956,6 @@
             "deps": [
                 "/lib/libc.so.6",
                 "/lib/libgcc_s.so.1",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libWPEFrameworkCore.so.2",
-                "/usr/lib/libWPEFrameworkPlugins.so.2",
-                "/usr/lib/libWPEFrameworkTracing.so.2",
-                "/usr/lib/libbreakpadwrapper.so.0",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtelemetry_msgsender.so.0"
-            ],
-            "name": "/usr/lib/wpeframework/plugins/libWPEFrameworkLoggingPreferences.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libWPEFrameworkCore.so.2",
-                "/usr/lib/libWPEFrameworkCryptalgo.so.2",
-                "/usr/lib/libWPEFrameworkDefinitions.so.2",
-                "/usr/lib/libWPEFrameworkPlugins.so.2",
-                "/usr/lib/libWPEFrameworkTracing.so.2",
-                "/usr/lib/libbreakpadwrapper.so.0",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtelemetry_msgsender.so.0"
-            ],
-            "name": "/usr/lib/wpeframework/plugins/libWPEFrameworkMessenger.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
                 "/usr/lib/libWPEFrameworkCore.so.2",
                 "/usr/lib/libWPEFrameworkPlugins.so.2",
                 "/usr/lib/libWPEFrameworkTracing.so.2",
@@ -17448,21 +12964,6 @@
                 "/usr/lib/libtelemetry_msgsender.so.0"
             ],
             "name": "/usr/lib/wpeframework/plugins/libWPEFrameworkMonitor.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libWPEFrameworkCore.so.2",
-                "/usr/lib/libWPEFrameworkPlugins.so.2",
-                "/usr/lib/libWPEFrameworkTracing.so.2",
-                "/usr/lib/libbreakpadwrapper.so.0",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtelemetry_msgsender.so.0"
-            ],
-            "name": "/usr/lib/wpeframework/plugins/libWPEFrameworkNetwork.so"
         },
         {
             "apiversions": [],
@@ -17478,21 +12979,6 @@
                 "/usr/lib/libtelemetry_msgsender.so.0"
             ],
             "name": "/usr/lib/wpeframework/plugins/libWPEFrameworkOCIContainer.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libWPEFrameworkCore.so.2",
-                "/usr/lib/libWPEFrameworkPlugins.so.2",
-                "/usr/lib/libWPEFrameworkTracing.so.2",
-                "/usr/lib/libbreakpadwrapper.so.0",
-                "/usr/lib/libsqlite3.so.0",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtelemetry_msgsender.so.0"
-            ],
-            "name": "/usr/lib/wpeframework/plugins/libWPEFrameworkPersistentStore.so"
         },
         {
             "apiversions": [],
@@ -17517,6 +13003,7 @@
             "deps": [
                 "/lib/libc.so.6",
                 "/lib/libgcc_s.so.1",
+                "/usr/lib/libRialtoServerManager.so.1",
                 "/usr/lib/libWPEFrameworkCore.so.2",
                 "/usr/lib/libWPEFrameworkPlugins.so.2",
                 "/usr/lib/libWPEFrameworkProtocols.so.2",
@@ -17524,8 +13011,7 @@
                 "/usr/lib/libbreakpadwrapper.so.0",
                 "/usr/lib/librdkshell.so",
                 "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtelemetry_msgsender.so.0",
-                "/usr/lib/libtrower-base64.so.1.0.0"
+                "/usr/lib/libtelemetry_msgsender.so.0"
             ],
             "name": "/usr/lib/wpeframework/plugins/libWPEFrameworkRDKShell.so"
         },
@@ -17534,76 +13020,6 @@
             "deps": [
                 "/lib/libc.so.6",
                 "/lib/libgcc_s.so.1",
-                "/usr/lib/libWPEFrameworkCore.so.2",
-                "/usr/lib/libWPEFrameworkPlugins.so.2",
-                "/usr/lib/libWPEFrameworkTracing.so.2",
-                "/usr/lib/libbreakpadwrapper.so.0",
-                "/usr/lib/libcurl.so.4",
-                "/usr/lib/libpng16.so.16",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtelemetry_msgsender.so.0"
-            ],
-            "name": "/usr/lib/wpeframework/plugins/libWPEFrameworkScreenCapture.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/ld-linux-armhf.so.3",
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libWPEFrameworkCore.so.2",
-                "/usr/lib/libWPEFrameworkPlugins.so.2",
-                "/usr/lib/libWPEFrameworkTracing.so.2",
-                "/usr/lib/libbreakpadwrapper.so.0",
-                "/usr/lib/libcurl.so.4",
-                "/usr/lib/libds.so",
-                "/usr/lib/librfcapi.so.0",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtelemetry_msgsender.so.0"
-            ],
-            "name": "/usr/lib/wpeframework/plugins/libWPEFrameworkSystemServices.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libWPEFrameworkCore.so.2",
-                "/usr/lib/libWPEFrameworkPlugins.so.2",
-                "/usr/lib/libWPEFrameworkTracing.so.2",
-                "/usr/lib/libbreakpadwrapper.so.0",
-                "/usr/lib/librbus.so.0",
-                "/usr/lib/librfcapi.so.0",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtelemetry_msgsender.so.0"
-            ],
-            "name": "/usr/lib/wpeframework/plugins/libWPEFrameworkTelemetry.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libWPEFrameworkCore.so.2",
-                "/usr/lib/libWPEFrameworkPlugins.so.2",
-                "/usr/lib/libWPEFrameworkProtocols.so.2",
-                "/usr/lib/libWPEFrameworkTracing.so.2",
-                "/usr/lib/libbreakpadwrapper.so.0",
-                "/usr/lib/libcurl.so.4",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libgobject-2.0.so.0",
-                "/usr/lib/libgstreamer-1.0.so.0",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtelemetry_msgsender.so.0"
-            ],
-            "name": "/usr/lib/wpeframework/plugins/libWPEFrameworkTextToSpeech.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
                 "/usr/lib/libIARMBus.so.0",
                 "/usr/lib/libWPEFrameworkCore.so.2",
                 "/usr/lib/libWPEFrameworkPlugins.so.2",
@@ -17612,7 +13028,7 @@
                 "/usr/lib/libstdc++.so.6",
                 "/usr/lib/libtelemetry_msgsender.so.0"
             ],
-            "name": "/usr/lib/wpeframework/plugins/libWPEFrameworkTimer.so"
+            "name": "/usr/lib/wpeframework/plugins/libWPEFrameworkRemoteControl.so"
         },
         {
             "apiversions": [],
@@ -17628,69 +13044,6 @@
                 "/usr/lib/libtelemetry_msgsender.so.0"
             ],
             "name": "/usr/lib/wpeframework/plugins/libWPEFrameworkTraceControl.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/ld-linux-armhf.so.3",
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/lib/libudev.so.1",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libWPEFrameworkCore.so.2",
-                "/usr/lib/libWPEFrameworkPlugins.so.2",
-                "/usr/lib/libWPEFrameworkTracing.so.2",
-                "/usr/lib/libbreakpadwrapper.so.0",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtelemetry_msgsender.so.0"
-            ],
-            "name": "/usr/lib/wpeframework/plugins/libWPEFrameworkUsbAccess.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libWPEFrameworkCore.so.2",
-                "/usr/lib/libWPEFrameworkPlugins.so.2",
-                "/usr/lib/libWPEFrameworkTracing.so.2",
-                "/usr/lib/libbreakpadwrapper.so.0",
-                "/usr/lib/libglib-2.0.so.0",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtelemetry_msgsender.so.0"
-            ],
-            "name": "/usr/lib/wpeframework/plugins/libWPEFrameworkUserPreferences.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libWPEFrameworkCore.so.2",
-                "/usr/lib/libWPEFrameworkPlugins.so.2",
-                "/usr/lib/libWPEFrameworkTracing.so.2",
-                "/usr/lib/libbreakpadwrapper.so.0",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtelemetry_msgsender.so.0"
-            ],
-            "name": "/usr/lib/wpeframework/plugins/libWPEFrameworkVoiceControl.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libWPEFrameworkCore.so.2",
-                "/usr/lib/libWPEFrameworkPlugins.so.2",
-                "/usr/lib/libWPEFrameworkTracing.so.2",
-                "/usr/lib/libbreakpadwrapper.so.0",
-                "/usr/lib/libds.so",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtelemetry_msgsender.so.0"
-            ],
-            "name": "/usr/lib/wpeframework/plugins/libWPEFrameworkWarehouse.so"
         },
         {
             "apiversions": [],
@@ -17723,40 +13076,6 @@
                 "/usr/lib/libwpe-1.0.so.1"
             ],
             "name": "/usr/lib/wpeframework/plugins/libWPEFrameworkWebKitBrowserImpl.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libWPEFrameworkCore.so.2",
-                "/usr/lib/libWPEFrameworkPlugins.so.2",
-                "/usr/lib/libWPEFrameworkTracing.so.2",
-                "/usr/lib/libbreakpadwrapper.so.0",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtelemetry_msgsender.so.0"
-            ],
-            "name": "/usr/lib/wpeframework/plugins/libWPEFrameworkWifiManager.so"
-        },
-        {
-            "apiversions": [],
-            "deps": [
-                "/lib/libc.so.6",
-                "/lib/libgcc_s.so.1",
-                "/usr/lib/libIARMBus.so.0",
-                "/usr/lib/libWPEFrameworkCore.so.2",
-                "/usr/lib/libWPEFrameworkPlugins.so.2",
-                "/usr/lib/libWPEFrameworkTracing.so.2",
-                "/usr/lib/libbreakpadwrapper.so.0",
-                "/usr/lib/libcjson.so.1",
-                "/usr/lib/librfcapi.so.0",
-                "/usr/lib/librtCore.so",
-                "/usr/lib/librtRemote.so",
-                "/usr/lib/libstdc++.so.6",
-                "/usr/lib/libtelemetry_msgsender.so.0"
-            ],
-            "name": "/usr/lib/wpeframework/plugins/libWPEFrameworkXCast.so"
         },
         {
             "apiversions": [],


### PR DESCRIPTION
* target is latest reference image build for raspberrypi4-64-rdk-android-mc
* DAC apps do not start when /dev/dri/card1 missing
* DAC apps render slow (swrast) when /dev/dri/renderD128 missing
* swrast_dri.so not needed when doing vc4_dri rendering