### PR TITLE
Add environment variable to control connection heartbeat

### DIFF
--- a/bundlegen/rabbitmq/main.py
+++ b/bundlegen/rabbitmq/main.py
@@ -108,10 +108,12 @@ def start():
                 connection = pika.BlockingConnection(
                     pika.ConnectionParameters(host=os.environ.get('RABBITMQ_HOST'),
                                               port=os.environ.get('RABBITMQ_PORT'),
+                                              heartbeat=int(os.environ.get('RABBITMQ_HEARTBEAT_SECONDS', 60)),
                                               connection_attempts=3, retry_delay=1))
             else:
                 connection = pika.BlockingConnection(
                     pika.ConnectionParameters(host=os.environ.get('RABBITMQ_HOST'),
+                                              heartbeat=int(os.environ.get('RABBITMQ_HEARTBEAT_SECONDS', 60)),
                                               connection_attempts=3, retry_delay=1))
 
             channel = connection.channel()


### PR DESCRIPTION
This patch introduces a new environment variable,
RABBITMQ_HEARTBEAT_SECONDS, that controls the timing of channel heartbeat. Previously, when generating bundles took more time than set in the default heartbeat value, the bundle generator had no chance of returning a successful message due to channel closure despite successfully generating the bundle. By setting the RABBITMQ_HEARTBEAT_SECONDS environment variable, we can ensure that the channel remains open until the bundle generation is complete, thus allowing the generator to return a successful message.

Note: The default value of heartbeat that is set when environment variable is unset (60 seconds) is taken from the Pika documentation.