### PR TITLE
REFPLTB-3201 : Create RPI4 Reference Broadband Kirkstone JSON for BundleGen templates/generic

### DIFF
--- a/templates/generic/rpi4_64_reference_bb_kirkstone.json
+++ b/templates/generic/rpi4_64_reference_bb_kirkstone.json
@@ -1,0 +1,122 @@
+{
+    "platformName": "rpi4_64_reference",
+    "os": "linux",
+    "arch": {
+        "arch": "aarch64",
+        "variant": "v8"
+    },
+    "rdk": {
+        "version": "2024Q3",
+        "supportedFeatures": [
+            "DeviceInfo",
+            "org.rdk.Network",
+            "org.rdk.OCIContainer",
+            "org.rdk.Proxies"
+        ]
+    },
+    "hardware": {
+            "graphics":false
+    },
+    "storage": {
+        "persistent": {
+            "storageDir": "/opt/dac_apps/data/0",
+            "maxSize": "100M"
+        }
+    },
+    "gpu": {
+        "extraMounts": [
+            {
+                "source": "/etc/ssl/certs",
+                "destination": "/etc/ssl/certs",
+                "type": "bind",
+                "options": [
+                    "rbind",
+                    "nosuid",
+                    "nodev",
+                    "ro",
+                    "X-mount.mkdir"
+                ]
+            },
+            {
+                "source": "/usr/share/ca-certificates",
+                "destination": "/usr/share/ca-certificates",
+                "type": "bind",
+                "options": [
+                    "rbind",
+                    "nosuid",
+                    "nodev",
+                    "ro",
+                    "X-mount.mkdir"
+                ]
+            }
+        ],
+        "envvar": [
+            "XDG_RUNTIME_DIR=/tmp"
+        ],
+        "devs": [
+        ],
+        "gfxLibs": [
+        ]
+    },
+    "mounts": [
+        {
+            "source": "/usr/lib/libstdc++.so.6",
+            "destination": "/usr/lib/libstdc++.so.6",
+            "options": [
+                "rbind",
+                "nosuid",
+                "nodev",
+                "ro"
+            ],
+            "type": "bind"
+        },
+        {
+            "source": "/lib/libgcc_s.so.1",
+            "destination": "/lib/libgcc_s.so.1",
+            "options": [
+                "rbind",
+                "nosuid",
+                "nodev",
+                "ro"
+            ],
+            "type": "bind"
+        },
+       {
+            "source": "tmpfs",
+            "destination": "/tmp",
+            "options": [
+                "nosuid",
+                "strictatime",
+                "mode=755",
+                "size=65536k"
+            ],
+            "type": "tmpfs"
+        }
+    ],
+    "network": {
+        "options": [
+            "nat",
+            "open",
+            "private"
+        ]
+    },
+    "envvar": [
+    ],
+    "resourceLimits": [
+        {
+            "type": "RLIMIT_NPROC",
+            "hard": 300,
+            "soft": 300
+        },
+        {
+            "type": "RLIMIT_RTPRIO",
+            "hard": 6,
+            "soft": 6
+        }
+    ],
+    "disableUserNamespacing": true,
+    "logging": {
+        "mode": "file",
+        "logDir": "/var/log"
+    }
+}

--- a/templates/generic/rpi4_64_reference_bb_kirkstone_libs.json
+++ b/templates/generic/rpi4_64_reference_bb_kirkstone_libs.json
@@ -1,0 +1,9443 @@
+{
+    "libs": [
+        {
+            "apiversions": [
+                "GLIBC_2.17",
+                "GLIBC_2.34",
+                "GLIBC_2.35",
+                "GLIBC_PRIVATE"
+            ],
+            "deps": [],
+            "name": "/lib/ld-linux-aarch64.so.1"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.17"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libBrokenLocale.so.1"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.17"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libanl.so.1"
+        },
+        {
+            "apiversions": [
+                "BLKID_1.0",
+                "BLKID_2.15",
+                "BLKID_2.17",
+                "BLKID_2.18",
+                "BLKID_2.20",
+                "BLKID_2.21",
+                "BLKID_2.23",
+                "BLKID_2.25",
+                "BLKID_2.30",
+                "BLKID_2_31",
+                "BLKID_2_36",
+                "BLKID_2_37"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libblkid.so.1"
+        },
+        {
+            "apiversions": [
+                "BLKID_1.0",
+                "BLKID_2.15",
+                "BLKID_2.17",
+                "BLKID_2.18",
+                "BLKID_2.20",
+                "BLKID_2.21",
+                "BLKID_2.23",
+                "BLKID_2.25",
+                "BLKID_2.30",
+                "BLKID_2_31",
+                "BLKID_2_36",
+                "BLKID_2_37"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libblkid.so.1.1.0"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.17",
+                "GLIBC_2.18",
+                "GLIBC_2.22",
+                "GLIBC_2.23",
+                "GLIBC_2.24",
+                "GLIBC_2.25",
+                "GLIBC_2.26",
+                "GLIBC_2.27",
+                "GLIBC_2.28",
+                "GLIBC_2.29",
+                "GLIBC_2.30",
+                "GLIBC_2.31",
+                "GLIBC_2.32",
+                "GLIBC_2.33",
+                "GLIBC_2.34",
+                "GLIBC_2.35",
+                "GLIBC_PRIVATE"
+            ],
+            "deps": [
+                "/lib/ld-linux-aarch64.so.1"
+            ],
+            "name": "/lib/libc.so.6"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.17",
+                "GLIBC_2.33"
+            ],
+            "deps": [
+                "/lib/ld-linux-aarch64.so.1",
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libc_malloc_debug.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libcap-ng.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libcap-ng.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libcap.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libcap.so.2.65"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libcom_err.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libcom_err.so.2.1"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.17"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libdl.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libe2p.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libe2p.so.2.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libcom_err.so.2"
+            ],
+            "name": "/lib/libext2fs.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libcom_err.so.2"
+            ],
+            "name": "/lib/libext2fs.so.2.4"
+        },
+        {
+            "apiversions": [
+                "FDISK_2.26",
+                "FDISK_2.27",
+                "FDISK_2.28",
+                "FDISK_2.29",
+                "FDISK_2.30",
+                "FDISK_2.31",
+                "FDISK_2.32",
+                "FDISK_2.33",
+                "FDISK_2.35",
+                "FDISK_2.36"
+            ],
+            "deps": [
+                "/lib/libblkid.so.1",
+                "/lib/libc.so.6",
+                "/usr/lib/libuuid.so.1"
+            ],
+            "name": "/lib/libfdisk.so.1"
+        },
+        {
+            "apiversions": [
+                "FDISK_2.26",
+                "FDISK_2.27",
+                "FDISK_2.28",
+                "FDISK_2.29",
+                "FDISK_2.30",
+                "FDISK_2.31",
+                "FDISK_2.32",
+                "FDISK_2.33",
+                "FDISK_2.35",
+                "FDISK_2.36"
+            ],
+            "deps": [
+                "/lib/libblkid.so.1",
+                "/lib/libc.so.6",
+                "/usr/lib/libuuid.so.1"
+            ],
+            "name": "/lib/libfdisk.so.1.1.0"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.0",
+                "GCC_3.0",
+                "GCC_3.3",
+                "GCC_3.3.1",
+                "GCC_3.4",
+                "GCC_3.4.2",
+                "GCC_3.4.4",
+                "GCC_4.0.0",
+                "GCC_4.2.0",
+                "GCC_4.3.0",
+                "GCC_4.5.0",
+                "GCC_4.7.0",
+                "GCC_7.0.0",
+                "GCC_11.0"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libgcc_s.so.1"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.17",
+                "GLIBC_2.18",
+                "GLIBC_2.23",
+                "GLIBC_2.24",
+                "GLIBC_2.25",
+                "GLIBC_2.27",
+                "GLIBC_2.28",
+                "GLIBC_2.29",
+                "GLIBC_2.31",
+                "GLIBC_2.32",
+                "GLIBC_2.35"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libm.so.6"
+        },
+        {
+            "apiversions": [
+                "MOUNT_2.19",
+                "MOUNT_2.20",
+                "MOUNT_2.21",
+                "MOUNT_2.22",
+                "MOUNT_2.23",
+                "MOUNT_2.24",
+                "MOUNT_2.25",
+                "MOUNT_2.26",
+                "MOUNT_2.28",
+                "MOUNT_2.30",
+                "MOUNT_2.33",
+                "MOUNT_2.34",
+                "MOUNT_2_35",
+                "MOUNT_2_37"
+            ],
+            "deps": [
+                "/lib/libblkid.so.1",
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libmount.so.1"
+        },
+        {
+            "apiversions": [
+                "MOUNT_2.19",
+                "MOUNT_2.20",
+                "MOUNT_2.21",
+                "MOUNT_2.22",
+                "MOUNT_2.23",
+                "MOUNT_2.24",
+                "MOUNT_2.25",
+                "MOUNT_2.26",
+                "MOUNT_2.28",
+                "MOUNT_2.30",
+                "MOUNT_2.33",
+                "MOUNT_2.34",
+                "MOUNT_2_35",
+                "MOUNT_2_37"
+            ],
+            "deps": [
+                "/lib/libblkid.so.1",
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libmount.so.1.1.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libtinfo.so.5"
+            ],
+            "name": "/lib/libncurses.so.5"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libtinfo.so.5"
+            ],
+            "name": "/lib/libncurses.so.5.9"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libtinfo.so.5"
+            ],
+            "name": "/lib/libncursesw.so.5"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libtinfo.so.5"
+            ],
+            "name": "/lib/libncursesw.so.5.9"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.17",
+                "GLIBC_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libnsl.so.1"
+        },
+        {
+            "apiversions": [
+                "GLIBC_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libnss_compat.so.2"
+        },
+        {
+            "apiversions": [
+                "GLIBC_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libnss_db.so.2"
+        },
+        {
+            "apiversions": [
+                "GLIBC_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libnss_dns.so.2"
+        },
+        {
+            "apiversions": [
+                "GLIBC_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libnss_files.so.2"
+        },
+        {
+            "apiversions": [
+                "GLIBC_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libresolv.so.2"
+            ],
+            "name": "/lib/libnss_hesiod.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/ld-linux-aarch64.so.1",
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libnss_myhostname.so.2"
+        },
+        {
+            "apiversions": [
+                "LIBPAM_1.0",
+                "LIBPAM_EXTENSION_1.0",
+                "LIBPAM_EXTENSION_1.1",
+                "LIBPAM_EXTENSION_1.1.1",
+                "LIBPAM_MODUTIL_1.0",
+                "LIBPAM_MODUTIL_1.1",
+                "LIBPAM_MODUTIL_1.1.3",
+                "LIBPAM_MODUTIL_1.1.9",
+                "LIBPAM_MODUTIL_1.3.2",
+                "LIBPAM_1.4",
+                "LIBPAM_MODUTIL_1.4.1"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libpam.so.0"
+        },
+        {
+            "apiversions": [
+                "LIBPAM_1.0",
+                "LIBPAM_EXTENSION_1.0",
+                "LIBPAM_EXTENSION_1.1",
+                "LIBPAM_EXTENSION_1.1.1",
+                "LIBPAM_MODUTIL_1.0",
+                "LIBPAM_MODUTIL_1.1",
+                "LIBPAM_MODUTIL_1.1.3",
+                "LIBPAM_MODUTIL_1.1.9",
+                "LIBPAM_MODUTIL_1.3.2",
+                "LIBPAM_1.4",
+                "LIBPAM_MODUTIL_1.4.1"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libpam.so.0.85.1"
+        },
+        {
+            "apiversions": [
+                "LIBPAM_MISC_1.0"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/libpam_misc.so.0"
+        },
+        {
+            "apiversions": [
+                "LIBPAM_MISC_1.0"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/libpam_misc.so.0.82.1"
+        },
+        {
+            "apiversions": [
+                "LIBPAMC_1.0"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libpamc.so.0"
+        },
+        {
+            "apiversions": [
+                "LIBPAMC_1.0"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libpamc.so.0.82.1"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.17",
+                "GLIBC_2.18",
+                "GLIBC_2.28",
+                "GLIBC_2.30",
+                "GLIBC_2.31"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libpthread.so.0"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.17",
+                "GLIBC_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libresolv.so.2"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.17"
+            ],
+            "deps": [
+                "/lib/ld-linux-aarch64.so.1",
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/librt.so.1"
+        },
+        {
+            "apiversions": [
+                "SMARTCOLS_2.25",
+                "SMARTCOLS_2.27",
+                "SMARTCOLS_2.28",
+                "SMARTCOLS_2.29",
+                "SMARTCOLS_2.30",
+                "SMARTCOLS_2.31",
+                "SMARTCOLS_2.33",
+                "SMARTCOLS_2.34",
+                "SMARTCOLS_2.35"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libsmartcols.so.1"
+        },
+        {
+            "apiversions": [
+                "SMARTCOLS_2.25",
+                "SMARTCOLS_2.27",
+                "SMARTCOLS_2.28",
+                "SMARTCOLS_2.29",
+                "SMARTCOLS_2.30",
+                "SMARTCOLS_2.31",
+                "SMARTCOLS_2.33",
+                "SMARTCOLS_2.34",
+                "SMARTCOLS_2.35"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libsmartcols.so.1.1.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libcom_err.so.2"
+            ],
+            "name": "/lib/libss.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libcom_err.so.2"
+            ],
+            "name": "/lib/libss.so.2.0"
+        },
+        {
+            "apiversions": [
+                "LIBSYSTEMD_209",
+                "LIBSYSTEMD_211",
+                "LIBSYSTEMD_213",
+                "LIBSYSTEMD_214",
+                "LIBSYSTEMD_216",
+                "LIBSYSTEMD_217",
+                "LIBSYSTEMD_219",
+                "LIBSYSTEMD_220",
+                "LIBSYSTEMD_221",
+                "LIBSYSTEMD_222",
+                "LIBSYSTEMD_226",
+                "LIBSYSTEMD_227",
+                "LIBSYSTEMD_229",
+                "LIBSYSTEMD_230",
+                "LIBSYSTEMD_231",
+                "LIBSYSTEMD_232",
+                "LIBSYSTEMD_233",
+                "LIBSYSTEMD_234",
+                "LIBSYSTEMD_236",
+                "LIBSYSTEMD_237",
+                "LIBSYSTEMD_238",
+                "LIBSYSTEMD_239",
+                "LIBSYSTEMD_240",
+                "LIBSYSTEMD_241",
+                "LIBSYSTEMD_243",
+                "LIBSYSTEMD_245",
+                "LIBSYSTEMD_246",
+                "LIBSYSTEMD_247",
+                "LIBSYSTEMD_248",
+                "LIBSYSTEMD_249",
+                "LIBSYSTEMD_250"
+            ],
+            "deps": [
+                "/lib/ld-linux-aarch64.so.1",
+                "/lib/libc.so.6",
+                "/lib/libcap.so.2",
+                "/usr/lib/libzstd.so.1"
+            ],
+            "name": "/lib/libsystemd.so.0"
+        },
+        {
+            "apiversions": [
+                "LIBSYSTEMD_209",
+                "LIBSYSTEMD_211",
+                "LIBSYSTEMD_213",
+                "LIBSYSTEMD_214",
+                "LIBSYSTEMD_216",
+                "LIBSYSTEMD_217",
+                "LIBSYSTEMD_219",
+                "LIBSYSTEMD_220",
+                "LIBSYSTEMD_221",
+                "LIBSYSTEMD_222",
+                "LIBSYSTEMD_226",
+                "LIBSYSTEMD_227",
+                "LIBSYSTEMD_229",
+                "LIBSYSTEMD_230",
+                "LIBSYSTEMD_231",
+                "LIBSYSTEMD_232",
+                "LIBSYSTEMD_233",
+                "LIBSYSTEMD_234",
+                "LIBSYSTEMD_236",
+                "LIBSYSTEMD_237",
+                "LIBSYSTEMD_238",
+                "LIBSYSTEMD_239",
+                "LIBSYSTEMD_240",
+                "LIBSYSTEMD_241",
+                "LIBSYSTEMD_243",
+                "LIBSYSTEMD_245",
+                "LIBSYSTEMD_246",
+                "LIBSYSTEMD_247",
+                "LIBSYSTEMD_248",
+                "LIBSYSTEMD_249",
+                "LIBSYSTEMD_250"
+            ],
+            "deps": [
+                "/lib/ld-linux-aarch64.so.1",
+                "/lib/libc.so.6",
+                "/lib/libcap.so.2",
+                "/usr/lib/libzstd.so.1"
+            ],
+            "name": "/lib/libsystemd.so.0.33.0"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.17"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libthread_db.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libtinfo.so.5"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libtinfo.so.5.9"
+        },
+        {
+            "apiversions": [
+                "LIBUDEV_183",
+                "LIBUDEV_189",
+                "LIBUDEV_196",
+                "LIBUDEV_199",
+                "LIBUDEV_215",
+                "LIBUDEV_247"
+            ],
+            "deps": [
+                "/lib/ld-linux-aarch64.so.1",
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libudev.so.1"
+        },
+        {
+            "apiversions": [
+                "LIBUDEV_183",
+                "LIBUDEV_189",
+                "LIBUDEV_196",
+                "LIBUDEV_199",
+                "LIBUDEV_215",
+                "LIBUDEV_247"
+            ],
+            "deps": [
+                "/lib/ld-linux-aarch64.so.1",
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libudev.so.1.7.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libudev.so.1",
+                "/usr/lib/libatomic.so.1"
+            ],
+            "name": "/lib/libusb-1.0.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libudev.so.1",
+                "/usr/lib/libatomic.so.1"
+            ],
+            "name": "/lib/libusb-1.0.so.0.3.0"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.17"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libutil.so.1"
+        },
+        {
+            "apiversions": [
+                "ZLIB_1.2.0",
+                "ZLIB_1.2.0.2",
+                "ZLIB_1.2.0.8",
+                "ZLIB_1.2.2",
+                "ZLIB_1.2.2.3",
+                "ZLIB_1.2.2.4",
+                "ZLIB_1.2.3.3",
+                "ZLIB_1.2.3.4",
+                "ZLIB_1.2.3.5",
+                "ZLIB_1.2.5.1",
+                "ZLIB_1.2.5.2",
+                "ZLIB_1.2.7.1",
+                "ZLIB_1.2.9"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libz.so.1"
+        },
+        {
+            "apiversions": [
+                "ZLIB_1.2.0",
+                "ZLIB_1.2.0.2",
+                "ZLIB_1.2.0.8",
+                "ZLIB_1.2.2",
+                "ZLIB_1.2.2.3",
+                "ZLIB_1.2.2.4",
+                "ZLIB_1.2.3.3",
+                "ZLIB_1.2.3.4",
+                "ZLIB_1.2.3.5",
+                "ZLIB_1.2.5.1",
+                "ZLIB_1.2.5.2",
+                "ZLIB_1.2.7.1",
+                "ZLIB_1.2.9"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libz.so.1.2.11"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libcap.so.2",
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/security/pam_cap.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/security/pam_deny.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/security/pam_env.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/security/pam_faildelay.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/security/pam_group.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/security/pam_lastlog.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/security/pam_limits.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/security/pam_mail.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/security/pam_motd.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/security/pam_nologin.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/security/pam_permit.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/security/pam_rootok.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/security/pam_securetty.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/security/pam_shells.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0",
+                "/usr/lib/libcrypt.so.2"
+            ],
+            "name": "/lib/security/pam_unix.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/security/pam_warn.so"
+        },
+        {
+            "apiversions": [
+                "SD_SHARED"
+            ],
+            "deps": [
+                "/lib/ld-linux-aarch64.so.1",
+                "/lib/libblkid.so.1",
+                "/lib/libc.so.6",
+                "/lib/libcap.so.2",
+                "/lib/libm.so.6",
+                "/lib/libmount.so.1",
+                "/usr/lib/libcrypt.so.2",
+                "/usr/lib/libkmod.so.2",
+                "/usr/lib/libzstd.so.1"
+            ],
+            "name": "/lib/systemd/libsystemd-shared-250.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-altair-lte.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-anydata.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-broadmobi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-cinterion.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-dell.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-dlink.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-ericsson-mbm.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-fibocom.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-foxconn.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-generic.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-gosuncn.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-haier.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-huawei.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-iridium.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-linktop.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-longcheer.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-motorola.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-mtk.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-nokia-icera.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-nokia.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-novatel-lte.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-novatel.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-option-hso.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-option.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-pantech.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-qcom-soc.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-quectel.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-samsung.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-sierra-legacy.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-sierra.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-simtech.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-telit.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-thuraya.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-tplink.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-ublox.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-via.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-wavecom.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-x22x.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-zte.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0",
+                "/usr/lib/libqmi-glib.so.5"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-shared-foxconn.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-shared-icera.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-shared-novatel.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-shared-option.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-shared-sierra.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-shared-telit.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-shared-xmm.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/usr/lib/libgcrypt.so.20"
+            ],
+            "name": "/usr/lib/crda/libreg.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libgcrypt.so.20"
+            ],
+            "name": "/usr/lib/ecryptfs/libecryptfs_key_mod_openssl.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgcrypt.so.20"
+            ],
+            "name": "/usr/lib/ecryptfs/libecryptfs_key_mod_passphrase.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/gio/modules/libgioenvironmentproxy.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/gio/modules/libgioopenssl.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libunwind.so.8"
+            ],
+            "name": "/usr/lib/heaptrack/libheaptrack_inject.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libunwind.so.8"
+            ],
+            "name": "/usr/lib/heaptrack/libheaptrack_preload.so"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.17"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libBrokenLocale.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libavro.so.23",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcimplog.so.1.0.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_wifi.so.0",
+                "/usr/lib/liblibparodus.so",
+                "/usr/lib/liblog4c.so.3",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbuscore.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/librtMessage.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libuuid.so.1",
+                "/usr/lib/libwrp-c.so"
+            ],
+            "name": "/usr/lib/libHarvesterSsp.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libavro.so.23",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcimplog.so.1.0.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_wifi.so.0",
+                "/usr/lib/liblibparodus.so",
+                "/usr/lib/liblog4c.so.3",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbuscore.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/librtMessage.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libuuid.so.1",
+                "/usr/lib/libwrp-c.so"
+            ],
+            "name": "/usr/lib/libHarvesterSsp.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libavro.so.23",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcimplog.so.1.0.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_wifi.so.0",
+                "/usr/lib/liblibparodus.so",
+                "/usr/lib/liblog4c.so.3",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbuscore.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/librtMessage.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libuuid.so.1",
+                "/usr/lib/libwrp-c.so"
+            ],
+            "name": "/usr/lib/libHarvesterSsp.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/libz.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libjansson.so.4",
+                "/usr/lib/liblmapi.so.0",
+                "/usr/lib/libnetfilter_queue.so.1",
+                "/usr/lib/libnfnetlink.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libulog.so.0"
+            ],
+            "name": "/usr/lib/libHotspotApi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/libz.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libjansson.so.4",
+                "/usr/lib/liblmapi.so.0",
+                "/usr/lib/libnetfilter_queue.so.1",
+                "/usr/lib/libnfnetlink.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libulog.so.0"
+            ],
+            "name": "/usr/lib/libHotspotApi.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/libz.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libjansson.so.4",
+                "/usr/lib/liblmapi.so.0",
+                "/usr/lib/libnetfilter_queue.so.1",
+                "/usr/lib/libnfnetlink.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libulog.so.0"
+            ],
+            "name": "/usr/lib/libHotspotApi.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libXmeshDiags.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/liblibparodus.so",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprint_uptime.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libulog.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libwebconfig_framework.so.0",
+                "/usr/lib/libwrp-c.so"
+            ],
+            "name": "/usr/lib/libMeshAgentSsp.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libXmeshDiags.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/liblibparodus.so",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprint_uptime.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libulog.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libwebconfig_framework.so.0",
+                "/usr/lib/libwrp-c.so"
+            ],
+            "name": "/usr/lib/libMeshAgentSsp.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libXmeshDiags.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/liblibparodus.so",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprint_uptime.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libulog.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libwebconfig_framework.so.0",
+                "/usr/lib/libwrp-c.so"
+            ],
+            "name": "/usr/lib/libMeshAgentSsp.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libOvsAgentSsp.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0"
+            ],
+            "name": "/usr/lib/libOvsAction.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libOvsAgentSsp.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0"
+            ],
+            "name": "/usr/lib/libOvsAction.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libOvsAgentSsp.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0"
+            ],
+            "name": "/usr/lib/libOvsAction.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libOvsDbApi.so.0",
+                "/usr/lib/libjansson.so.4",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0"
+            ],
+            "name": "/usr/lib/libOvsAgentApi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libOvsDbApi.so.0",
+                "/usr/lib/libjansson.so.4",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0"
+            ],
+            "name": "/usr/lib/libOvsAgentApi.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libOvsDbApi.so.0",
+                "/usr/lib/libjansson.so.4",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0"
+            ],
+            "name": "/usr/lib/libOvsAgentApi.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0"
+            ],
+            "name": "/usr/lib/libOvsAgentSsp.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0"
+            ],
+            "name": "/usr/lib/libOvsAgentSsp.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0"
+            ],
+            "name": "/usr/lib/libOvsAgentSsp.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libjansson.so.4",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0"
+            ],
+            "name": "/usr/lib/libOvsDbApi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libjansson.so.4",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0"
+            ],
+            "name": "/usr/lib/libOvsDbApi.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libjansson.so.4",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0"
+            ],
+            "name": "/usr/lib/libOvsDbApi.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libbulkdata.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libccspinterface.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libdcautil.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libhttp.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbusmethod.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libreportgen.so.0",
+                "/usr/lib/libscheduler.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2parser.so.0",
+                "/usr/lib/libt2utils.so.0",
+                "/usr/lib/libwebconfig_framework.so.0",
+                "/usr/lib/libxconfclient.so.0"
+            ],
+            "name": "/usr/lib/libT2_tr181.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libbulkdata.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libccspinterface.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libdcautil.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libhttp.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbusmethod.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libreportgen.so.0",
+                "/usr/lib/libscheduler.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2parser.so.0",
+                "/usr/lib/libt2utils.so.0",
+                "/usr/lib/libwebconfig_framework.so.0",
+                "/usr/lib/libxconfclient.so.0"
+            ],
+            "name": "/usr/lib/libT2_tr181.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libbulkdata.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libccspinterface.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libdcautil.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libhttp.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbusmethod.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libreportgen.so.0",
+                "/usr/lib/libscheduler.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2parser.so.0",
+                "/usr/lib/libt2utils.so.0",
+                "/usr/lib/libwebconfig_framework.so.0",
+                "/usr/lib/libxconfclient.so.0"
+            ],
+            "name": "/usr/lib/libT2_tr181.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/liblibparodus.so",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libwrp-c.so"
+            ],
+            "name": "/usr/lib/libXmeshDiags.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/liblibparodus.so",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libwrp-c.so"
+            ],
+            "name": "/usr/lib/libXmeshDiags.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/liblibparodus.so",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libwrp-c.so"
+            ],
+            "name": "/usr/lib/libXmeshDiags.so.0.0.0"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.17"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libanl.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libapi_dhcpv4c.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libapi_dhcpv4c.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libapm.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libapm.so.1.0.0"
+        },
+        {
+            "apiversions": [
+                "LIBATOMIC_1.0",
+                "LIBATOMIC_1.1",
+                "LIBATOMIC_1.2"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libatomic.so.1"
+        },
+        {
+            "apiversions": [
+                "LIBATOMIC_1.0",
+                "LIBATOMIC_1.1",
+                "LIBATOMIC_1.2"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libatomic.so.1.2.0"
+        },
+        {
+            "apiversions": [
+                "ATTR_1.0",
+                "ATTR_1.1",
+                "ATTR_1.2",
+                "ATTR_1.3"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libattr.so.1"
+        },
+        {
+            "apiversions": [
+                "ATTR_1.0",
+                "ATTR_1.1",
+                "ATTR_1.2",
+                "ATTR_1.3"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libattr.so.1.1.2501"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1",
+                "/usr/lib/libjansson.so.4",
+                "/usr/lib/liblzma.so.5"
+            ],
+            "name": "/usr/lib/libavro.so.23"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1",
+                "/usr/lib/libjansson.so.4",
+                "/usr/lib/liblzma.so.5"
+            ],
+            "name": "/usr/lib/libavro.so.23.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libbluetooth.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libbluetooth.so.3.19.8"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libbreakpadwrapper.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libbreakpadwrapper.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libccspinterface.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libdcautil.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libhttp.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbusmethod.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libreportgen.so.0",
+                "/usr/lib/libscheduler.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2parser.so.0",
+                "/usr/lib/libt2utils.so.0",
+                "/usr/lib/libwebconfig_framework.so.0",
+                "/usr/lib/libxconfclient.so.0"
+            ],
+            "name": "/usr/lib/libbulkdata.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libccspinterface.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libdcautil.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libhttp.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbusmethod.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libreportgen.so.0",
+                "/usr/lib/libscheduler.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2parser.so.0",
+                "/usr/lib/libt2utils.so.0",
+                "/usr/lib/libwebconfig_framework.so.0",
+                "/usr/lib/libxconfclient.so.0"
+            ],
+            "name": "/usr/lib/libbulkdata.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libccspinterface.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libdcautil.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libhttp.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbusmethod.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libreportgen.so.0",
+                "/usr/lib/libscheduler.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2parser.so.0",
+                "/usr/lib/libt2utils.so.0",
+                "/usr/lib/libwebconfig_framework.so.0",
+                "/usr/lib/libxconfclient.so.0"
+            ],
+            "name": "/usr/lib/libbulkdata.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libbz2.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libbz2.so.1.0.8"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.17",
+                "GLIBC_2.33"
+            ],
+            "deps": [
+                "/lib/ld-linux-aarch64.so.1",
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libc_malloc_debug.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libcares.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libcares.so.2.5.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbuscore.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/librtMessage.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libssl.so.3",
+                "/usr/lib/libtrower-base64.so.1.0.0"
+            ],
+            "name": "/usr/lib/libccsp_common.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbuscore.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/librtMessage.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libssl.so.3",
+                "/usr/lib/libtrower-base64.so.1.0.0"
+            ],
+            "name": "/usr/lib/libccsp_common.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbuscore.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/librtMessage.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libssl.so.3",
+                "/usr/lib/libtrower-base64.so.1.0.0"
+            ],
+            "name": "/usr/lib/libccsp_common.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libccspinterface.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libccspinterface.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libccspinterface.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/librdkloggers.so.0"
+            ],
+            "name": "/usr/lib/libcimplog.so.1.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libcjson.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libcjson.so.1.7.15"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcjson.so.1"
+            ],
+            "name": "/usr/lib/libcjson_utils.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcjson.so.1"
+            ],
+            "name": "/usr/lib/libcjson_utils.so.1.7.15"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libcjwt.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libcm_mgnt.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libcm_mgnt.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcimplog.so.1.0.0",
+                "/usr/lib/libcm_mgnt.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libulog.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libwebconfig_framework.so.0"
+            ],
+            "name": "/usr/lib/libcm_tr181.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcimplog.so.1.0.0",
+                "/usr/lib/libcm_mgnt.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libulog.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libwebconfig_framework.so.0"
+            ],
+            "name": "/usr/lib/libcm_tr181.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcimplog.so.1.0.0",
+                "/usr/lib/libcm_mgnt.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libulog.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libwebconfig_framework.so.0"
+            ],
+            "name": "/usr/lib/libcm_tr181.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcimplog.so.1.0.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/libwdmp-c.so"
+            ],
+            "name": "/usr/lib/libcpeabs.so"
+        },
+        {
+            "apiversions": [
+                "XCRYPT_2.0",
+                "XCRYPT_4.3",
+                "XCRYPT_4.4"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libcrypt.so.2"
+        },
+        {
+            "apiversions": [
+                "XCRYPT_2.0",
+                "XCRYPT_4.3",
+                "XCRYPT_4.4"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libcrypt.so.2.0.0"
+        },
+        {
+            "apiversions": [
+                "OPENSSL_3.0.0",
+                "OPENSSL_3.0.3"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libcrypto.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libidn2.so.0",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/libcurl.so.4"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libidn2.so.0",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/libcurl.so.4.7.0"
+        },
+        {
+            "apiversions": [
+                "LIBDBUS_1_3",
+                "LIBDBUS_PRIVATE_1.14.0"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libsystemd.so.0"
+            ],
+            "name": "/usr/lib/libdbus-1.so.3"
+        },
+        {
+            "apiversions": [
+                "LIBDBUS_1_3",
+                "LIBDBUS_PRIVATE_1.14.0"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libsystemd.so.0"
+            ],
+            "name": "/usr/lib/libdbus-1.so.3.32.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libccspinterface.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2utils.so.0"
+            ],
+            "name": "/usr/lib/libdcautil.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libccspinterface.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2utils.so.0"
+            ],
+            "name": "/usr/lib/libdcautil.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libccspinterface.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2utils.so.0"
+            ],
+            "name": "/usr/lib/libdcautil.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libutctx.so.0"
+            ],
+            "name": "/usr/lib/libdhcp_client_utils.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libutctx.so.0"
+            ],
+            "name": "/usr/lib/libdhcp_client_utils.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libutctx.so.0"
+            ],
+            "name": "/usr/lib/libdhcp_client_utils.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libdiagnostic.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libdiagnostic.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libdiagnostic.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcm_mgnt.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libwebconfig_framework.so.0"
+            ],
+            "name": "/usr/lib/libdmlasecurity.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcm_mgnt.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libwebconfig_framework.so.0"
+            ],
+            "name": "/usr/lib/libdmlasecurity.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcm_mgnt.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libwebconfig_framework.so.0"
+            ],
+            "name": "/usr/lib/libdmlasecurity.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/libresolv.so.2",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libev.so.4",
+                "/usr/lib/libpcap.so.1",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0"
+            ],
+            "name": "/usr/lib/libdmltad.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/libresolv.so.2",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libev.so.4",
+                "/usr/lib/libpcap.so.1",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0"
+            ],
+            "name": "/usr/lib/libdmltad.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/libresolv.so.2",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libev.so.4",
+                "/usr/lib/libpcap.so.1",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0"
+            ],
+            "name": "/usr/lib/libdmltad.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libglog.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libwebconfig_framework.so.0"
+            ],
+            "name": "/usr/lib/libdmlxdns.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libglog.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libwebconfig_framework.so.0"
+            ],
+            "name": "/usr/lib/libdmlxdns.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libglog.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libwebconfig_framework.so.0"
+            ],
+            "name": "/usr/lib/libdmlxdns.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libdrop_ambient.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libdrop_ambient.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libebtc.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libebtc.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgcrypt.so.20",
+                "/usr/lib/libkeyutils.so.1"
+            ],
+            "name": "/usr/lib/libecryptfs.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgcrypt.so.20",
+                "/usr/lib/libkeyutils.so.1"
+            ],
+            "name": "/usr/lib/libecryptfs.so.1.0.0"
+        },
+        {
+            "apiversions": [
+                "ELFUTILS_1.0",
+                "ELFUTILS_1.1",
+                "ELFUTILS_1.1.1",
+                "ELFUTILS_1.2",
+                "ELFUTILS_1.3",
+                "ELFUTILS_1.4",
+                "ELFUTILS_1.5",
+                "ELFUTILS_1.6",
+                "ELFUTILS_1.7"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1"
+            ],
+            "name": "/usr/lib/libelf-0.186.so"
+        },
+        {
+            "apiversions": [
+                "ELFUTILS_1.0",
+                "ELFUTILS_1.1",
+                "ELFUTILS_1.1.1",
+                "ELFUTILS_1.2",
+                "ELFUTILS_1.3",
+                "ELFUTILS_1.4",
+                "ELFUTILS_1.5",
+                "ELFUTILS_1.6",
+                "ELFUTILS_1.7"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1"
+            ],
+            "name": "/usr/lib/libelf.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcm_mgnt.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_pon.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsyscfg.so.0"
+            ],
+            "name": "/usr/lib/libepon_tr181.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcm_mgnt.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_pon.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsyscfg.so.0"
+            ],
+            "name": "/usr/lib/libepon_tr181.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcm_mgnt.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_pon.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsyscfg.so.0"
+            ],
+            "name": "/usr/lib/libepon_tr181.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6"
+            ],
+            "name": "/usr/lib/libev.so.4"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6"
+            ],
+            "name": "/usr/lib/libev.so.4.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libevent-2.1.so.7"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libevent-2.1.so.7.0.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libexpat.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libexpat.so.1.8.9"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6",
+                "/usr/lib/libfcgi.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libfcgi++.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6",
+                "/usr/lib/libfcgi.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libfcgi++.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libfcgi.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libfcgi.so.0.0.0"
+        },
+        {
+            "apiversions": [
+                "LIBFFI_BASE_8.0",
+                "LIBFFI_COMPLEX_8.0",
+                "LIBFFI_CLOSURE_8.0",
+                "LIBFFI_GO_CLOSURE_8.0"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libffi.so.8"
+        },
+        {
+            "apiversions": [
+                "LIBFFI_BASE_8.0",
+                "LIBFFI_COMPLEX_8.0",
+                "LIBFFI_CLOSURE_8.0",
+                "LIBFFI_GO_CLOSURE_8.0"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libffi.so.8.1.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/librt.so.1",
+                "/usr/lib/libcrypt.so.2"
+            ],
+            "name": "/usr/lib/libfpm_pb.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/librt.so.1",
+                "/usr/lib/libcrypt.so.2"
+            ],
+            "name": "/usr/lib/libfpm_pb.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libfw_upgrade.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libfw_upgrade.so.0.0.0"
+        },
+        {
+            "apiversions": [
+                "GCRYPT_1.6"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libcap.so.2",
+                "/usr/lib/libgpg-error.so.0"
+            ],
+            "name": "/usr/lib/libgcrypt.so.20"
+        },
+        {
+            "apiversions": [
+                "GCRYPT_1.6"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libcap.so.2",
+                "/usr/lib/libgpg-error.so.0"
+            ],
+            "name": "/usr/lib/libgcrypt.so.20.3.4"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libgdbm.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libgdbm.so.3.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libgdbm_compat.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libgdbm_compat.so.3.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libmount.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgmodule-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/libgio-2.0.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libmount.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgmodule-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/libgio-2.0.so.0.7400.6"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libpcre2-8.so.0"
+            ],
+            "name": "/usr/lib/libglib-2.0.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libpcre2-8.so.0"
+            ],
+            "name": "/usr/lib/libglib-2.0.so.0.7400.6"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libunwind.so.8"
+            ],
+            "name": "/usr/lib/libglog.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libunwind.so.8"
+            ],
+            "name": "/usr/lib/libglog.so.0.5.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libglib-2.0.so.0"
+            ],
+            "name": "/usr/lib/libgmodule-2.0.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libglib-2.0.so.0"
+            ],
+            "name": "/usr/lib/libgmodule-2.0.so.0.7400.6"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libgmp.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libgmp.so.3.4.1"
+        },
+        {
+            "apiversions": [
+                "GNUTLS_1_4",
+                "GNUTLS_2_8",
+                "GNUTLS_2_10",
+                "GNUTLS_2_12",
+                "GNUTLS_3_0_0",
+                "GNUTLS_3_1_0",
+                "GNUTLS_FIPS140",
+                "GNUTLS_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1",
+                "/usr/lib/libgmp.so.3",
+                "/usr/lib/libhogweed.so.2",
+                "/usr/lib/libnettle.so.4"
+            ],
+            "name": "/usr/lib/libgnutls.so.28"
+        },
+        {
+            "apiversions": [
+                "GNUTLS_1_4",
+                "GNUTLS_2_8",
+                "GNUTLS_2_10",
+                "GNUTLS_2_12",
+                "GNUTLS_3_0_0",
+                "GNUTLS_3_1_0",
+                "GNUTLS_FIPS140",
+                "GNUTLS_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1",
+                "/usr/lib/libgmp.so.3",
+                "/usr/lib/libhogweed.so.2",
+                "/usr/lib/libnettle.so.4"
+            ],
+            "name": "/usr/lib/libgnutls.so.28.43.4"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libffi.so.8",
+                "/usr/lib/libglib-2.0.so.0"
+            ],
+            "name": "/usr/lib/libgobject-2.0.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libffi.so.8",
+                "/usr/lib/libglib-2.0.so.0"
+            ],
+            "name": "/usr/lib/libgobject-2.0.so.0.7400.6"
+        },
+        {
+            "apiversions": [
+                "GPG_ERROR_1.0"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libgpg-error.so.0"
+        },
+        {
+            "apiversions": [
+                "GPG_ERROR_1.0"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libgpg-error.so.0.32.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libsoup-2.4.so.1"
+            ],
+            "name": "/usr/lib/libgssdp-1.2.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libsoup-2.4.so.1"
+            ],
+            "name": "/usr/lib/libgssdp-1.2.so.0.104.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0"
+            ],
+            "name": "/usr/lib/libgthread-2.0.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0"
+            ],
+            "name": "/usr/lib/libgthread-2.0.so.0.7400.6"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libudev.so.1",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/libgudev-1.0.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libudev.so.1",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/libgudev-1.0.so.0.3.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgmodule-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libgssdp-1.2.so.0",
+                "/usr/lib/libsoup-2.4.so.1",
+                "/usr/lib/libuuid.so.1",
+                "/usr/lib/libxml2.so.2"
+            ],
+            "name": "/usr/lib/libgupnp-1.0.so.4"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgmodule-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libgssdp-1.2.so.0",
+                "/usr/lib/libsoup-2.4.so.1",
+                "/usr/lib/libuuid.so.1",
+                "/usr/lib/libxml2.so.2"
+            ],
+            "name": "/usr/lib/libgupnp-1.0.so.4.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0"
+            ],
+            "name": "/usr/lib/libhal_ethsw.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0"
+            ],
+            "name": "/usr/lib/libhal_ethsw.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libhal_moca.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libhal_moca.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/libhal_msomgmt.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/libhal_msomgmt.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libhal_mta.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libhal_mta.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libhal_platform.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libhal_platform.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/libhal_pon.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/libhal_pon.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libhal_vlan.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libhal_vlan.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libev.so.4",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libwpa_client.so"
+            ],
+            "name": "/usr/lib/libhal_wifi.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libev.so.4",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libwpa_client.so"
+            ],
+            "name": "/usr/lib/libhal_wifi.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libhistory.so.5"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libhistory.so.5.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgmp.so.3",
+                "/usr/lib/libnettle.so.4"
+            ],
+            "name": "/usr/lib/libhogweed.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgmp.so.3",
+                "/usr/lib/libnettle.so.4"
+            ],
+            "name": "/usr/lib/libhogweed.so.2.5"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/libhostap.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/libhostap.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libhttp.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libhttp.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libhttp.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libical.so.3"
+            ],
+            "name": "/usr/lib/libical-glib.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libical.so.3"
+            ],
+            "name": "/usr/lib/libical-glib.so.3.0.14"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libicui18n.so.70",
+                "/usr/lib/libicuuc.so.70"
+            ],
+            "name": "/usr/lib/libical.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libicui18n.so.70",
+                "/usr/lib/libicuuc.so.70"
+            ],
+            "name": "/usr/lib/libical.so.3.0.14"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libical.so.3",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libical_cxx.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libical.so.3",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libical_cxx.so.3.0.14"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libical.so.3"
+            ],
+            "name": "/usr/lib/libicalss.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libical.so.3"
+            ],
+            "name": "/usr/lib/libicalss.so.3.0.14"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libical.so.3",
+                "/usr/lib/libical_cxx.so.3",
+                "/usr/lib/libicalss.so.3",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libicalss_cxx.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libical.so.3",
+                "/usr/lib/libical_cxx.so.3",
+                "/usr/lib/libicalss.so.3",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libicalss_cxx.so.3.0.14"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libical.so.3"
+            ],
+            "name": "/usr/lib/libicalvcal.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libical.so.3"
+            ],
+            "name": "/usr/lib/libicalvcal.so.3.0.14"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libicudata.so.70"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libicudata.so.70.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libicudata.so.70",
+                "/usr/lib/libicuuc.so.70",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libicui18n.so.70"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libicudata.so.70",
+                "/usr/lib/libicuuc.so.70",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libicui18n.so.70.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libicudata.so.70",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libicuuc.so.70"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libicudata.so.70",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libicuuc.so.70.1"
+        },
+        {
+            "apiversions": [
+                "IDN2_0.0.0",
+                "IDN2_2.1.0"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libunistring.so.2"
+            ],
+            "name": "/usr/lib/libidn2.so.0"
+        },
+        {
+            "apiversions": [
+                "IDN2_0.0.0",
+                "IDN2_2.1.0"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libunistring.so.2"
+            ],
+            "name": "/usr/lib/libidn2.so.0.3.7"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libmbedcrypto.so.3",
+                "/usr/lib/libmbedtls.so.12",
+                "/usr/lib/libmbedx509.so.0"
+            ],
+            "name": "/usr/lib/libiksemel.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libmbedcrypto.so.3",
+                "/usr/lib/libmbedtls.so.12",
+                "/usr/lib/libmbedx509.so.0"
+            ],
+            "name": "/usr/lib/libiksemel.so.3.1.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libinterChipHelper.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libinterChipHelper.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libinterChipHelper.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libip4tc.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libip4tc.so.2.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libip6tc.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libip6tc.so.2.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libixml.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libixml.so.2.0.8"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libjansson.so.4"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libjansson.so.4.13.0"
+        },
+        {
+            "apiversions": [
+                "JSONC_PRIVATE",
+                "JSONC_0.14",
+                "JSONC_0.15"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libjson-c.so.5"
+        },
+        {
+            "apiversions": [
+                "JSONC_PRIVATE",
+                "JSONC_0.14",
+                "JSONC_0.15"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libjson-c.so.5.1.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libjson-c.so.5"
+            ],
+            "name": "/usr/lib/libjson_hal_client.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libjson-c.so.5"
+            ],
+            "name": "/usr/lib/libjson_hal_client.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libjson-c.so.5"
+            ],
+            "name": "/usr/lib/libjson_hal_server.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libjson-c.so.5"
+            ],
+            "name": "/usr/lib/libjson_hal_server.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libnlohmann_json_schema_validator.so.1",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libjson_schema_validator_wrapper.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libnlohmann_json_schema_validator.so.1",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libjson_schema_validator_wrapper.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libjsoncpp.so.1.9.5"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libjsoncpp.so.25"
+        },
+        {
+            "apiversions": [
+                "KEYUTILS_0.3",
+                "KEYUTILS_1.0",
+                "KEYUTILS_1.3",
+                "KEYUTILS_1.4",
+                "KEYUTILS_1.5",
+                "KEYUTILS_1.6",
+                "KEYUTILS_1.7",
+                "KEYUTILS_1.8",
+                "KEYUTILS_1.9"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libkeyutils.so.1"
+        },
+        {
+            "apiversions": [
+                "KEYUTILS_0.3",
+                "KEYUTILS_1.0",
+                "KEYUTILS_1.3",
+                "KEYUTILS_1.4",
+                "KEYUTILS_1.5",
+                "KEYUTILS_1.6",
+                "KEYUTILS_1.7",
+                "KEYUTILS_1.8",
+                "KEYUTILS_1.9"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libkeyutils.so.1.9"
+        },
+        {
+            "apiversions": [
+                "LIBKMOD_5",
+                "LIBKMOD_6",
+                "LIBKMOD_22"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1",
+                "/usr/lib/liblzma.so.5"
+            ],
+            "name": "/usr/lib/libkmod.so.2"
+        },
+        {
+            "apiversions": [
+                "LIBKMOD_5",
+                "LIBKMOD_6",
+                "LIBKMOD_22"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1",
+                "/usr/lib/liblzma.so.5"
+            ],
+            "name": "/usr/lib/libkmod.so.2.3.7"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libwrp-c.so"
+            ],
+            "name": "/usr/lib/liblibparodus.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcimplog.so.1.0.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/libwrp-c.so"
+            ],
+            "name": "/usr/lib/liblibseshat.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/liblinenoise.so.1.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbuscore.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/librtMessage.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libxml2.so.2"
+            ],
+            "name": "/usr/lib/liblmapi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbuscore.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/librtMessage.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libxml2.so.2"
+            ],
+            "name": "/usr/lib/liblmapi.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbuscore.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/librtMessage.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libxml2.so.2"
+            ],
+            "name": "/usr/lib/liblmapi.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0"
+            ],
+            "name": "/usr/lib/liblog4c.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0"
+            ],
+            "name": "/usr/lib/liblog4c.so.3.3.0"
+        },
+        {
+            "apiversions": [
+                "XZ_5.0",
+                "XZ_5.2"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0"
+            ],
+            "name": "/usr/lib/liblzma.so.5"
+        },
+        {
+            "apiversions": [
+                "XZ_5.0",
+                "XZ_5.2"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0"
+            ],
+            "name": "/usr/lib/liblzma.so.5.2.6"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/liblzo2.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/liblzo2.so.2.0.0"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.17",
+                "GLIBC_2.18",
+                "GLIBC_2.23",
+                "GLIBC_2.24",
+                "GLIBC_2.25",
+                "GLIBC_2.27",
+                "GLIBC_2.28",
+                "GLIBC_2.29",
+                "GLIBC_2.31",
+                "GLIBC_2.32",
+                "GLIBC_2.35"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libm.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libmbedcrypto.so.2.16.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libmbedcrypto.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libmbedcrypto.so.3",
+                "/usr/lib/libmbedx509.so.0"
+            ],
+            "name": "/usr/lib/libmbedtls.so.12"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libmbedcrypto.so.3",
+                "/usr/lib/libmbedx509.so.0"
+            ],
+            "name": "/usr/lib/libmbedtls.so.2.16.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libmbedcrypto.so.3"
+            ],
+            "name": "/usr/lib/libmbedx509.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libmbedcrypto.so.3"
+            ],
+            "name": "/usr/lib/libmbedx509.so.2.16.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/libmbim-glib.so.4"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/libmbim-glib.so.4.6.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/libmm-glib.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/libmm-glib.so.0.8.0"
+        },
+        {
+            "apiversions": [
+                "LIBMNL_1.0",
+                "LIBMNL_1.1",
+                "LIBMNL_1.2"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libmnl.so.0"
+        },
+        {
+            "apiversions": [
+                "LIBMNL_1.0",
+                "LIBMNL_1.1",
+                "LIBMNL_1.2"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libmnl.so.0.2.0"
+        },
+        {
+            "apiversions": [
+                "MOSQ_1.0",
+                "MOSQ_1.1",
+                "MOSQ_1.2",
+                "MOSQ_1.3",
+                "MOSQ_1.4",
+                "MOSQ_1.5",
+                "MOSQ_1.6",
+                "MOSQ_1.7"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/libmosquitto.so.1"
+        },
+        {
+            "apiversions": [
+                "MOSQ_1.0",
+                "MOSQ_1.1",
+                "MOSQ_1.2",
+                "MOSQ_1.3",
+                "MOSQ_1.4",
+                "MOSQ_1.5",
+                "MOSQ_1.6",
+                "MOSQ_1.7"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/libmosquitto.so.2.0.14"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libmsgpackc.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libmsgpackc.so.2.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_mta.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libulog.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0"
+            ],
+            "name": "/usr/lib/libmta_tr181.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_mta.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libulog.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0"
+            ],
+            "name": "/usr/lib/libmta_tr181.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_mta.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libulog.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0"
+            ],
+            "name": "/usr/lib/libmta_tr181.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libnanomsg.so.5"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libnanomsg.so.5.1.0"
+        },
+        {
+            "apiversions": [
+                "NEON_0_29",
+                "NEON_0_30"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libexpat.so.1",
+                "/usr/lib/libproxy.so.1",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/libneon.so.27"
+        },
+        {
+            "apiversions": [
+                "NEON_0_29",
+                "NEON_0_30"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libexpat.so.1",
+                "/usr/lib/libproxy.so.1",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/libneon.so.27.3.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libnl-3.so.200",
+                "/usr/lib/libnl-nf-3.so.200",
+                "/usr/lib/libnl-route-3.so.200",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libnet.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libnl-3.so.200",
+                "/usr/lib/libnl-nf-3.so.200",
+                "/usr/lib/libnl-route-3.so.200",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libnet.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libmnl.so.0",
+                "/usr/lib/libnfnetlink.so.0"
+            ],
+            "name": "/usr/lib/libnetfilter_conntrack.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libmnl.so.0",
+                "/usr/lib/libnfnetlink.so.0"
+            ],
+            "name": "/usr/lib/libnetfilter_conntrack.so.3.8.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libmnl.so.0",
+                "/usr/lib/libnfnetlink.so.0"
+            ],
+            "name": "/usr/lib/libnetfilter_queue.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libmnl.so.0",
+                "/usr/lib/libnfnetlink.so.0"
+            ],
+            "name": "/usr/lib/libnetfilter_queue.so.1.5.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/libnetsnmp.so.40"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/libnetsnmp.so.40.1.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libnetsnmp.so.40"
+            ],
+            "name": "/usr/lib/libnetsnmpagent.so.40"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libnetsnmp.so.40"
+            ],
+            "name": "/usr/lib/libnetsnmpagent.so.40.1.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/libnetsnmphelpers.so.40"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/libnetsnmphelpers.so.40.1.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libnetsnmp.so.40",
+                "/usr/lib/libnetsnmpagent.so.40",
+                "/usr/lib/libpci.so.3"
+            ],
+            "name": "/usr/lib/libnetsnmpmibs.so.40"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libnetsnmp.so.40",
+                "/usr/lib/libnetsnmpagent.so.40",
+                "/usr/lib/libpci.so.3"
+            ],
+            "name": "/usr/lib/libnetsnmpmibs.so.40.1.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libnettle.so.4"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libnettle.so.4.7"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libnfnetlink.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libnfnetlink.so.0.2.0"
+        },
+        {
+            "apiversions": [
+                "libnl_3",
+                "libnl_3_2_26",
+                "libnl_3_2_27",
+                "libnl_3_2_28",
+                "libnl_3_2_29",
+                "libnl_3_5"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0"
+            ],
+            "name": "/usr/lib/libnl-3.so.200"
+        },
+        {
+            "apiversions": [
+                "libnl_3",
+                "libnl_3_2_26",
+                "libnl_3_2_27",
+                "libnl_3_2_28",
+                "libnl_3_2_29",
+                "libnl_3_5"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0"
+            ],
+            "name": "/usr/lib/libnl-3.so.200.26.0"
+        },
+        {
+            "apiversions": [
+                "libnl_3"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libnl-3.so.200"
+            ],
+            "name": "/usr/lib/libnl-genl-3.so.200"
+        },
+        {
+            "apiversions": [
+                "libnl_3"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libnl-3.so.200"
+            ],
+            "name": "/usr/lib/libnl-genl-3.so.200.26.0"
+        },
+        {
+            "apiversions": [
+                "libnl_3"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libnl-3.so.200",
+                "/usr/lib/libnl-route-3.so.200"
+            ],
+            "name": "/usr/lib/libnl-nf-3.so.200"
+        },
+        {
+            "apiversions": [
+                "libnl_3"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libnl-3.so.200",
+                "/usr/lib/libnl-route-3.so.200"
+            ],
+            "name": "/usr/lib/libnl-nf-3.so.200.26.0"
+        },
+        {
+            "apiversions": [
+                "libnl_3",
+                "libnl_3_2_26",
+                "libnl_3_2_27",
+                "libnl_3_2_28",
+                "libnl_3_2_29",
+                "libnl_3_4",
+                "libnl_3_5"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libnl-3.so.200"
+            ],
+            "name": "/usr/lib/libnl-route-3.so.200"
+        },
+        {
+            "apiversions": [
+                "libnl_3",
+                "libnl_3_2_26",
+                "libnl_3_2_27",
+                "libnl_3_2_28",
+                "libnl_3_2_29",
+                "libnl_3_4",
+                "libnl_3_5"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libnl-3.so.200"
+            ],
+            "name": "/usr/lib/libnl-route-3.so.200.26.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libnlohmann_json_schema_validator.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libnlohmann_json_schema_validator.so.2.1.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/ld-linux-aarch64.so.1",
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/libnopoll.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/ld-linux-aarch64.so.1",
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/libnopoll.so.0.0.0"
+        },
+        {
+            "apiversions": [
+                "LIBNSL_2.0",
+                "LIBNSL_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libtirpc.so.3"
+            ],
+            "name": "/usr/lib/libnsl.so.3"
+        },
+        {
+            "apiversions": [
+                "LIBNSL_2.0",
+                "LIBNSL_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libtirpc.so.3"
+            ],
+            "name": "/usr/lib/libnsl.so.3.0.0"
+        },
+        {
+            "apiversions": [
+                "GLIBC_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libnss_compat.so"
+        },
+        {
+            "apiversions": [
+                "GLIBC_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libnss_db.so"
+        },
+        {
+            "apiversions": [
+                "GLIBC_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libresolv.so.2"
+            ],
+            "name": "/usr/lib/libnss_hesiod.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libyajl.so.2"
+            ],
+            "name": "/usr/lib/libocispec.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libyajl.so.2"
+            ],
+            "name": "/usr/lib/libocispec.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libixml.so.2",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtirpc.so.3",
+                "/usr/lib/libupnp.so.6"
+            ],
+            "name": "/usr/lib/libpal.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libixml.so.2",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtirpc.so.3",
+                "/usr/lib/libupnp.so.6"
+            ],
+            "name": "/usr/lib/libpal.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libixml.so.2",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtirpc.so.3",
+                "/usr/lib/libupnp.so.6"
+            ],
+            "name": "/usr/lib/libpal.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libncursesw.so.5",
+                "/lib/libtinfo.so.5"
+            ],
+            "name": "/usr/lib/libpanelw.so.5"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libncursesw.so.5",
+                "/lib/libtinfo.so.5"
+            ],
+            "name": "/usr/lib/libpanelw.so.5.9"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libpcap.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libpcap.so.1.10.1"
+        },
+        {
+            "apiversions": [
+                "LIBPCI_3.0",
+                "LIBPCI_3.1",
+                "LIBPCI_3.2",
+                "LIBPCI_3.3",
+                "LIBPCI_3.4",
+                "LIBPCI_3.5",
+                "LIBPCI_3.6",
+                "LIBPCI_3.7"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libresolv.so.2",
+                "/lib/libudev.so.1",
+                "/lib/libz.so.1"
+            ],
+            "name": "/usr/lib/libpci.so.3"
+        },
+        {
+            "apiversions": [
+                "LIBPCI_3.0",
+                "LIBPCI_3.1",
+                "LIBPCI_3.2",
+                "LIBPCI_3.3",
+                "LIBPCI_3.4",
+                "LIBPCI_3.5",
+                "LIBPCI_3.6",
+                "LIBPCI_3.7"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libresolv.so.2",
+                "/lib/libudev.so.1",
+                "/lib/libz.so.1"
+            ],
+            "name": "/usr/lib/libpci.so.3.7.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libpcre.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libpcre.so.1.2.7"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libpcre2-8.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libpcre2-8.so.0.11.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libpcre2-8.so.0"
+            ],
+            "name": "/usr/lib/libpcre2-posix.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libpcre2-8.so.0"
+            ],
+            "name": "/usr/lib/libpcre2-posix.so.3.0.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libpcre32.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libpcre32.so.0.0.7"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libpcre.so.1"
+            ],
+            "name": "/usr/lib/libpcreposix.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libpcre.so.1"
+            ],
+            "name": "/usr/lib/libpcreposix.so.0.0.4"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/usr/lib/libcrypt.so.2"
+            ],
+            "name": "/usr/lib/libperl.so.5"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/usr/lib/libcrypt.so.2"
+            ],
+            "name": "/usr/lib/libperl.so.5.34.0"
+        },
+        {
+            "apiversions": [
+                "LIBPOPT_0"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libpopt.so.0"
+        },
+        {
+            "apiversions": [
+                "LIBPOPT_0"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libpopt.so.0.0.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtirpc.so.3"
+            ],
+            "name": "/usr/lib/libprint_uptime.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtirpc.so.3"
+            ],
+            "name": "/usr/lib/libprint_uptime.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtirpc.so.3"
+            ],
+            "name": "/usr/lib/libprint_uptime.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libcap.so.2",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6",
+                "/usr/lib/libjsoncpp.so.25",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libprivilege.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libcap.so.2",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6",
+                "/usr/lib/libjsoncpp.so.25",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libprivilege.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libcap.so.2",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6",
+                "/usr/lib/libjsoncpp.so.25",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libprivilege.so.0.0.0"
+        },
+        {
+            "apiversions": [
+                "LIBPROCPS_0"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libsystemd.so.0"
+            ],
+            "name": "/usr/lib/libprocps.so.8"
+        },
+        {
+            "apiversions": [
+                "LIBPROCPS_0"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libsystemd.so.0"
+            ],
+            "name": "/usr/lib/libprocps.so.8.0.3"
+        },
+        {
+            "apiversions": [
+                "LIBPROTOBUF_C_1.0.0",
+                "LIBPROTOBUF_C_1.3.0"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libprotobuf-c.so.1"
+        },
+        {
+            "apiversions": [
+                "LIBPROTOBUF_C_1.0.0",
+                "LIBPROTOBUF_C_1.3.0"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libprotobuf-c.so.1.0.0"
+        },
+        {
+            "apiversions": [
+                "LIBPROXY_0.4.16"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libproxy.so.1"
+        },
+        {
+            "apiversions": [
+                "LIBPROXY_0.4.16"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libproxy.so.1.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libproxy.so.1",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libproxy/0.4.17/modules/config_gnome3.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libicudata.so.70",
+                "/usr/lib/libicuuc.so.70"
+            ],
+            "name": "/usr/lib/libpsl.so.5"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libicudata.so.70",
+                "/usr/lib/libicuuc.so.70"
+            ],
+            "name": "/usr/lib/libpsl.so.5.3.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libpsx.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libpsx.so.2.65"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.17",
+                "GLIBC_2.18",
+                "GLIBC_2.28",
+                "GLIBC_2.30",
+                "GLIBC_2.31"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libpthread.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6"
+            ],
+            "name": "/usr/lib/libpython3.10.so.1.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmbim-glib.so.4"
+            ],
+            "name": "/usr/lib/libqmi-glib.so.5"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmbim-glib.so.4"
+            ],
+            "name": "/usr/lib/libqmi-glib.so.5.8.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/librt.so.1",
+                "/usr/lib/libcrypt.so.2"
+            ],
+            "name": "/usr/lib/libquagga_pb.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/librt.so.1",
+                "/usr/lib/libcrypt.so.2"
+            ],
+            "name": "/usr/lib/libquagga_pb.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/librbuscore.so.0",
+                "/usr/lib/librtMessage.so.0"
+            ],
+            "name": "/usr/lib/librbus.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/librbuscore.so.0",
+                "/usr/lib/librtMessage.so.0"
+            ],
+            "name": "/usr/lib/librbus.so.2.0.13"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/librtMessage.so.0"
+            ],
+            "name": "/usr/lib/librbuscore.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/librtMessage.so.0"
+            ],
+            "name": "/usr/lib/librbuscore.so.2.0.13"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/librbusmethod.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/librbusmethod.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/librbusmethod.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libhostap.so.0",
+                "/usr/lib/libnl-3.so.200",
+                "/usr/lib/libnl-genl-3.so.200",
+                "/usr/lib/libnl-route-3.so.200",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/librdk_wifihal.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libhostap.so.0",
+                "/usr/lib/libnl-3.so.200",
+                "/usr/lib/libnl-genl-3.so.200",
+                "/usr/lib/libnl-route-3.so.200",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/librdk_wifihal.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/liblog4c.so.3",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/librdkloggers.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/liblog4c.so.3",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/librdkloggers.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/librdmopenssl.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/librdmopenssl.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libtinfo.so.5"
+            ],
+            "name": "/usr/lib/libreadline.so.5"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libtinfo.so.5"
+            ],
+            "name": "/usr/lib/libreadline.so.5.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libreportgen.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libreportgen.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libreportgen.so.0.0.0"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.17",
+                "GLIBC_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libresolv.so"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.17"
+            ],
+            "deps": [
+                "/lib/ld-linux-aarch64.so.1",
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/librt.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/librdkloggers.so.0"
+            ],
+            "name": "/usr/lib/librtMessage.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/librdkloggers.so.0"
+            ],
+            "name": "/usr/lib/librtMessage.so.2.0.13"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/ld-linux-aarch64.so.1",
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libsafec.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/ld-linux-aarch64.so.1",
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libsafec.so.3.0.7"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2utils.so.0"
+            ],
+            "name": "/usr/lib/libscheduler.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2utils.so.0"
+            ],
+            "name": "/usr/lib/libscheduler.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2utils.so.0"
+            ],
+            "name": "/usr/lib/libscheduler.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libseccomp.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libseccomp.so.2.4.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/librdkloggers.so.0"
+            ],
+            "name": "/usr/lib/libsecure_wrapper.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/librdkloggers.so.0"
+            ],
+            "name": "/usr/lib/libsecure_wrapper.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libnetsnmp.so.40",
+                "/usr/lib/libnetsnmpagent.so.40",
+                "/usr/lib/libnetsnmpmibs.so.40",
+                "/usr/lib/libprint_uptime.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsnmp_plugin.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0"
+            ],
+            "name": "/usr/lib/libsnmp_custom.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libnetsnmp.so.40",
+                "/usr/lib/libnetsnmpagent.so.40",
+                "/usr/lib/libnetsnmpmibs.so.40",
+                "/usr/lib/libprint_uptime.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsnmp_plugin.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0"
+            ],
+            "name": "/usr/lib/libsnmp_custom.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libnetsnmp.so.40",
+                "/usr/lib/libnetsnmpagent.so.40",
+                "/usr/lib/libnetsnmpmibs.so.40",
+                "/usr/lib/libprint_uptime.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsnmp_plugin.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0"
+            ],
+            "name": "/usr/lib/libsnmp_custom.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libnetsnmp.so.40",
+                "/usr/lib/libnetsnmpagent.so.40",
+                "/usr/lib/libnetsnmpmibs.so.40",
+                "/usr/lib/libprint_uptime.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0"
+            ],
+            "name": "/usr/lib/libsnmp_plugin.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libnetsnmp.so.40",
+                "/usr/lib/libnetsnmpagent.so.40",
+                "/usr/lib/libnetsnmpmibs.so.40",
+                "/usr/lib/libprint_uptime.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0"
+            ],
+            "name": "/usr/lib/libsnmp_plugin.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libnetsnmp.so.40",
+                "/usr/lib/libnetsnmpagent.so.40",
+                "/usr/lib/libnetsnmpmibs.so.40",
+                "/usr/lib/libprint_uptime.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0"
+            ],
+            "name": "/usr/lib/libsnmp_plugin.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgmodule-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libpsl.so.5",
+                "/usr/lib/libsqlite3.so.0",
+                "/usr/lib/libxml2.so.2"
+            ],
+            "name": "/usr/lib/libsoup-2.4.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgmodule-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libpsl.so.5",
+                "/usr/lib/libsqlite3.so.0",
+                "/usr/lib/libxml2.so.2"
+            ],
+            "name": "/usr/lib/libsoup-2.4.so.1.11.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libsqlite3.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libsqlite3.so.0.8.6"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtirpc.so.3",
+                "/usr/lib/libulog.so.0"
+            ],
+            "name": "/usr/lib/libsrvmgr.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtirpc.so.3",
+                "/usr/lib/libulog.so.0"
+            ],
+            "name": "/usr/lib/libsrvmgr.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtirpc.so.3",
+                "/usr/lib/libulog.so.0"
+            ],
+            "name": "/usr/lib/libsrvmgr.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libssa.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libssa.so.0.0.0"
+        },
+        {
+            "apiversions": [
+                "OPENSSL_3.0.0"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcrypto.so.3"
+            ],
+            "name": "/usr/lib/libssl.so.3"
+        },
+        {
+            "apiversions": [
+                "GLIBCXX_3.4",
+                "GLIBCXX_3.4.1",
+                "GLIBCXX_3.4.2",
+                "GLIBCXX_3.4.3",
+                "GLIBCXX_3.4.4",
+                "GLIBCXX_3.4.5",
+                "GLIBCXX_3.4.6",
+                "GLIBCXX_3.4.7",
+                "GLIBCXX_3.4.8",
+                "GLIBCXX_3.4.9",
+                "GLIBCXX_3.4.10",
+                "GLIBCXX_3.4.11",
+                "GLIBCXX_3.4.12",
+                "GLIBCXX_3.4.13",
+                "GLIBCXX_3.4.14",
+                "GLIBCXX_3.4.15",
+                "GLIBCXX_3.4.16",
+                "GLIBCXX_3.4.17",
+                "GLIBCXX_3.4.18",
+                "GLIBCXX_3.4.19",
+                "GLIBCXX_3.4.20",
+                "GLIBCXX_3.4.21",
+                "GLIBCXX_3.4.22",
+                "GLIBCXX_3.4.23",
+                "GLIBCXX_3.4.24",
+                "GLIBCXX_3.4.25",
+                "GLIBCXX_3.4.26",
+                "GLIBCXX_3.4.27",
+                "GLIBCXX_3.4.28",
+                "GLIBCXX_3.4.29",
+                "CXXABI_1.3",
+                "CXXABI_1.3.1",
+                "CXXABI_1.3.2",
+                "CXXABI_1.3.3",
+                "CXXABI_1.3.4",
+                "CXXABI_1.3.5",
+                "CXXABI_1.3.6",
+                "CXXABI_1.3.7",
+                "CXXABI_1.3.8",
+                "CXXABI_1.3.9",
+                "CXXABI_1.3.10",
+                "CXXABI_1.3.11",
+                "CXXABI_1.3.12",
+                "CXXABI_1.3.13",
+                "CXXABI_TM_1"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6"
+            ],
+            "name": "/usr/lib/libstdc++.so"
+        },
+        {
+            "apiversions": [
+                "GLIBCXX_3.4",
+                "GLIBCXX_3.4.1",
+                "GLIBCXX_3.4.2",
+                "GLIBCXX_3.4.3",
+                "GLIBCXX_3.4.4",
+                "GLIBCXX_3.4.5",
+                "GLIBCXX_3.4.6",
+                "GLIBCXX_3.4.7",
+                "GLIBCXX_3.4.8",
+                "GLIBCXX_3.4.9",
+                "GLIBCXX_3.4.10",
+                "GLIBCXX_3.4.11",
+                "GLIBCXX_3.4.12",
+                "GLIBCXX_3.4.13",
+                "GLIBCXX_3.4.14",
+                "GLIBCXX_3.4.15",
+                "GLIBCXX_3.4.16",
+                "GLIBCXX_3.4.17",
+                "GLIBCXX_3.4.18",
+                "GLIBCXX_3.4.19",
+                "GLIBCXX_3.4.20",
+                "GLIBCXX_3.4.21",
+                "GLIBCXX_3.4.22",
+                "GLIBCXX_3.4.23",
+                "GLIBCXX_3.4.24",
+                "GLIBCXX_3.4.25",
+                "GLIBCXX_3.4.26",
+                "GLIBCXX_3.4.27",
+                "GLIBCXX_3.4.28",
+                "GLIBCXX_3.4.29",
+                "CXXABI_1.3",
+                "CXXABI_1.3.1",
+                "CXXABI_1.3.2",
+                "CXXABI_1.3.3",
+                "CXXABI_1.3.4",
+                "CXXABI_1.3.5",
+                "CXXABI_1.3.6",
+                "CXXABI_1.3.7",
+                "CXXABI_1.3.8",
+                "CXXABI_1.3.9",
+                "CXXABI_1.3.10",
+                "CXXABI_1.3.11",
+                "CXXABI_1.3.12",
+                "CXXABI_1.3.13",
+                "CXXABI_TM_1"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6"
+            ],
+            "name": "/usr/lib/libstdc++.so.6"
+        },
+        {
+            "apiversions": [
+                "GLIBCXX_3.4",
+                "GLIBCXX_3.4.1",
+                "GLIBCXX_3.4.2",
+                "GLIBCXX_3.4.3",
+                "GLIBCXX_3.4.4",
+                "GLIBCXX_3.4.5",
+                "GLIBCXX_3.4.6",
+                "GLIBCXX_3.4.7",
+                "GLIBCXX_3.4.8",
+                "GLIBCXX_3.4.9",
+                "GLIBCXX_3.4.10",
+                "GLIBCXX_3.4.11",
+                "GLIBCXX_3.4.12",
+                "GLIBCXX_3.4.13",
+                "GLIBCXX_3.4.14",
+                "GLIBCXX_3.4.15",
+                "GLIBCXX_3.4.16",
+                "GLIBCXX_3.4.17",
+                "GLIBCXX_3.4.18",
+                "GLIBCXX_3.4.19",
+                "GLIBCXX_3.4.20",
+                "GLIBCXX_3.4.21",
+                "GLIBCXX_3.4.22",
+                "GLIBCXX_3.4.23",
+                "GLIBCXX_3.4.24",
+                "GLIBCXX_3.4.25",
+                "GLIBCXX_3.4.26",
+                "GLIBCXX_3.4.27",
+                "GLIBCXX_3.4.28",
+                "GLIBCXX_3.4.29",
+                "CXXABI_1.3",
+                "CXXABI_1.3.1",
+                "CXXABI_1.3.2",
+                "CXXABI_1.3.3",
+                "CXXABI_1.3.4",
+                "CXXABI_1.3.5",
+                "CXXABI_1.3.6",
+                "CXXABI_1.3.7",
+                "CXXABI_1.3.8",
+                "CXXABI_1.3.9",
+                "CXXABI_1.3.10",
+                "CXXABI_1.3.11",
+                "CXXABI_1.3.12",
+                "CXXABI_1.3.13",
+                "CXXABI_TM_1"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6"
+            ],
+            "name": "/usr/lib/libstdc++.so.6.0.29"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0",
+                "/lib/libpam_misc.so.0",
+                "/usr/lib/libattr.so.1",
+                "/usr/lib/libcrypt.so.2"
+            ],
+            "name": "/usr/lib/libsubid.so.4"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0",
+                "/lib/libpam_misc.so.0",
+                "/usr/lib/libattr.so.1",
+                "/usr/lib/libcrypt.so.2"
+            ],
+            "name": "/usr/lib/libsubid.so.4.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtirpc.so.3",
+                "/usr/lib/libulog.so.0"
+            ],
+            "name": "/usr/lib/libsyscfg.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtirpc.so.3",
+                "/usr/lib/libulog.so.0"
+            ],
+            "name": "/usr/lib/libsyscfg.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtirpc.so.3",
+                "/usr/lib/libulog.so.0"
+            ],
+            "name": "/usr/lib/libsyscfg.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtirpc.so.3"
+            ],
+            "name": "/usr/lib/libsysevent.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtirpc.so.3"
+            ],
+            "name": "/usr/lib/libsysevent.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtirpc.so.3"
+            ],
+            "name": "/usr/lib/libsysevent.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libccspinterface.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2utils.so.0"
+            ],
+            "name": "/usr/lib/libt2parser.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libccspinterface.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2utils.so.0"
+            ],
+            "name": "/usr/lib/libt2parser.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libccspinterface.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2utils.so.0"
+            ],
+            "name": "/usr/lib/libt2parser.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libt2utils.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libt2utils.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libt2utils.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2utils.so.0"
+            ],
+            "name": "/usr/lib/libtelemetry_msgsender.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2utils.so.0"
+            ],
+            "name": "/usr/lib/libtelemetry_msgsender.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2utils.so.0"
+            ],
+            "name": "/usr/lib/libtelemetry_msgsender.so.0.0.0"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.17"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libthread_db.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libthreadutil.so.6"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libthreadutil.so.6.0.4"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libutctx.so.0"
+            ],
+            "name": "/usr/lib/libtime_conversion.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libutctx.so.0"
+            ],
+            "name": "/usr/lib/libtime_conversion.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libutctx.so.0"
+            ],
+            "name": "/usr/lib/libtime_conversion.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libtinyxml.so.2.6.2"
+        },
+        {
+            "apiversions": [
+                "TIRPC_0.3.0",
+                "TIRPC_0.3.1",
+                "TIRPC_0.3.2",
+                "TIRPC_0.3.3",
+                "TIRPC_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0"
+            ],
+            "name": "/usr/lib/libtirpc.so.3"
+        },
+        {
+            "apiversions": [
+                "TIRPC_0.3.0",
+                "TIRPC_0.3.1",
+                "TIRPC_0.3.2",
+                "TIRPC_0.3.3",
+                "TIRPC_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0"
+            ],
+            "name": "/usr/lib/libtirpc.so.3.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libHotspotApi.so.0",
+                "/usr/lib/libapi_dhcpv4c.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcm_mgnt.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libfw_upgrade.so.0",
+                "/usr/lib/libhal_ethsw.so.0",
+                "/usr/lib/libhal_moca.so.0",
+                "/usr/lib/libhal_msomgmt.so.0",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/liblibparodus.so",
+                "/usr/lib/liblmapi.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtime_conversion.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libwebconfig_framework.so.0",
+                "/usr/lib/libwrp-c.so"
+            ],
+            "name": "/usr/lib/libtr181.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libHotspotApi.so.0",
+                "/usr/lib/libapi_dhcpv4c.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcm_mgnt.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libfw_upgrade.so.0",
+                "/usr/lib/libhal_ethsw.so.0",
+                "/usr/lib/libhal_moca.so.0",
+                "/usr/lib/libhal_msomgmt.so.0",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/liblibparodus.so",
+                "/usr/lib/liblmapi.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtime_conversion.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libwebconfig_framework.so.0",
+                "/usr/lib/libwrp-c.so"
+            ],
+            "name": "/usr/lib/libtr181.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libHotspotApi.so.0",
+                "/usr/lib/libapi_dhcpv4c.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcm_mgnt.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libfw_upgrade.so.0",
+                "/usr/lib/libhal_ethsw.so.0",
+                "/usr/lib/libhal_moca.so.0",
+                "/usr/lib/libhal_msomgmt.so.0",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/liblibparodus.so",
+                "/usr/lib/liblmapi.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtime_conversion.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libwebconfig_framework.so.0",
+                "/usr/lib/libwrp-c.so"
+            ],
+            "name": "/usr/lib/libtr181.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/libtrower-base64.so.1.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libucresolv.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtirpc.so.3"
+            ],
+            "name": "/usr/lib/libulog.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtirpc.so.3"
+            ],
+            "name": "/usr/lib/libulog.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtirpc.so.3"
+            ],
+            "name": "/usr/lib/libulog.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libunistring.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libunistring.so.2.2.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libunwind.so.8"
+            ],
+            "name": "/usr/lib/libunwind-aarch64.so.8"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libunwind.so.8"
+            ],
+            "name": "/usr/lib/libunwind-aarch64.so.8.0.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1"
+            ],
+            "name": "/usr/lib/libunwind-coredump.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1"
+            ],
+            "name": "/usr/lib/libunwind-coredump.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1"
+            ],
+            "name": "/usr/lib/libunwind-ptrace.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1"
+            ],
+            "name": "/usr/lib/libunwind-ptrace.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libunwind-aarch64.so.8",
+                "/usr/lib/libunwind.so.8"
+            ],
+            "name": "/usr/lib/libunwind-setjmp.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libunwind-aarch64.so.8",
+                "/usr/lib/libunwind.so.8"
+            ],
+            "name": "/usr/lib/libunwind-setjmp.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1"
+            ],
+            "name": "/usr/lib/libunwind.so.8"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1"
+            ],
+            "name": "/usr/lib/libunwind.so.8.0.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libixml.so.2",
+                "/usr/lib/libthreadutil.so.6"
+            ],
+            "name": "/usr/lib/libupnp.so.6"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libixml.so.2",
+                "/usr/lib/libthreadutil.so.6"
+            ],
+            "name": "/usr/lib/libupnp.so.6.3.6"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcm_mgnt.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libffi.so.8",
+                "/usr/lib/libgcrypt.so.20",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgmodule-2.0.so.0",
+                "/usr/lib/libgnutls.so.28",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libgpg-error.so.0",
+                "/usr/lib/libgssdp-1.2.so.0",
+                "/usr/lib/libgthread-2.0.so.0",
+                "/usr/lib/libgupnp-1.0.so.4",
+                "/usr/lib/libhal_ethsw.so.0",
+                "/usr/lib/libhal_moca.so.0",
+                "/usr/lib/libhal_msomgmt.so.0",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/liblmapi.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsoup-2.4.so.1",
+                "/usr/lib/libsqlite3.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libxml2.so.2"
+            ],
+            "name": "/usr/lib/libupnpidm.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcm_mgnt.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libffi.so.8",
+                "/usr/lib/libgcrypt.so.20",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgmodule-2.0.so.0",
+                "/usr/lib/libgnutls.so.28",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libgpg-error.so.0",
+                "/usr/lib/libgssdp-1.2.so.0",
+                "/usr/lib/libgthread-2.0.so.0",
+                "/usr/lib/libgupnp-1.0.so.4",
+                "/usr/lib/libhal_ethsw.so.0",
+                "/usr/lib/libhal_moca.so.0",
+                "/usr/lib/libhal_msomgmt.so.0",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/liblmapi.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsoup-2.4.so.1",
+                "/usr/lib/libsqlite3.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libxml2.so.2"
+            ],
+            "name": "/usr/lib/libupnpidm.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtirpc.so.3",
+                "/usr/lib/libulog.so.0"
+            ],
+            "name": "/usr/lib/libutapi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtirpc.so.3",
+                "/usr/lib/libulog.so.0"
+            ],
+            "name": "/usr/lib/libutapi.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtirpc.so.3",
+                "/usr/lib/libulog.so.0"
+            ],
+            "name": "/usr/lib/libutapi.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtirpc.so.3",
+                "/usr/lib/libulog.so.0"
+            ],
+            "name": "/usr/lib/libutctx.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtirpc.so.3",
+                "/usr/lib/libulog.so.0"
+            ],
+            "name": "/usr/lib/libutctx.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtirpc.so.3",
+                "/usr/lib/libulog.so.0"
+            ],
+            "name": "/usr/lib/libutctx.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtirpc.so.3"
+            ],
+            "name": "/usr/lib/libutopiautil.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtirpc.so.3"
+            ],
+            "name": "/usr/lib/libutopiautil.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtirpc.so.3"
+            ],
+            "name": "/usr/lib/libutopiautil.so.0.0.0"
+        },
+        {
+            "apiversions": [
+                "UUID_1.0",
+                "UUID_2.20",
+                "UUID_2.31",
+                "UUID_2.36",
+                "UUIDD_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libuuid.so.1"
+        },
+        {
+            "apiversions": [
+                "UUID_1.0",
+                "UUID_2.20",
+                "UUID_2.31",
+                "UUID_2.36",
+                "UUIDD_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libuuid.so.1.3.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libwdmp-c.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbuscore.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/librtMessage.so.0"
+            ],
+            "name": "/usr/lib/libwebconfig_framework.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbuscore.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/librtMessage.so.0"
+            ],
+            "name": "/usr/lib/libwebconfig_framework.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbuscore.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/librtMessage.so.0"
+            ],
+            "name": "/usr/lib/libwebconfig_framework.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libavro.so.23",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libev.so.4",
+                "/usr/lib/libhal_wifi.so.0",
+                "/usr/lib/liblibparodus.so",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprint_uptime.so.0",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libuuid.so.1",
+                "/usr/lib/libwebconfig_framework.so.0",
+                "/usr/lib/libwifi_webconfig.so.0"
+            ],
+            "name": "/usr/lib/libwifi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libavro.so.23",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libev.so.4",
+                "/usr/lib/libhal_wifi.so.0",
+                "/usr/lib/liblibparodus.so",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprint_uptime.so.0",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libuuid.so.1",
+                "/usr/lib/libwebconfig_framework.so.0",
+                "/usr/lib/libwifi_webconfig.so.0"
+            ],
+            "name": "/usr/lib/libwifi.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libavro.so.23",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libev.so.4",
+                "/usr/lib/libhal_wifi.so.0",
+                "/usr/lib/liblibparodus.so",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprint_uptime.so.0",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libuuid.so.1",
+                "/usr/lib/libwebconfig_framework.so.0",
+                "/usr/lib/libwifi_webconfig.so.0"
+            ],
+            "name": "/usr/lib/libwifi.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libsystemd.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libjansson.so.4",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libssl.so.3",
+                "/usr/lib/libwebconfig_framework.so.0"
+            ],
+            "name": "/usr/lib/libwifi_webconfig.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libsystemd.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libjansson.so.4",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libssl.so.3",
+                "/usr/lib/libwebconfig_framework.so.0"
+            ],
+            "name": "/usr/lib/libwifi_webconfig.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libsystemd.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libjansson.so.4",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libssl.so.3",
+                "/usr/lib/libwebconfig_framework.so.0"
+            ],
+            "name": "/usr/lib/libwifi_webconfig.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libwpa_client.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcimplog.so.1.0.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libtrower-base64.so.1.0.0"
+            ],
+            "name": "/usr/lib/libwrp-c.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libccspinterface.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2parser.so.0",
+                "/usr/lib/libt2utils.so.0"
+            ],
+            "name": "/usr/lib/libxconfclient.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libccspinterface.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2parser.so.0",
+                "/usr/lib/libt2utils.so.0"
+            ],
+            "name": "/usr/lib/libxconfclient.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libccspinterface.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2parser.so.0",
+                "/usr/lib/libt2utils.so.0"
+            ],
+            "name": "/usr/lib/libxconfclient.so.0.0.0"
+        },
+        {
+            "apiversions": [
+                "LIBXML2_2.4.30",
+                "LIBXML2_2.5.0",
+                "LIBXML2_2.5.2",
+                "LIBXML2_2.5.4",
+                "LIBXML2_2.5.5",
+                "LIBXML2_2.5.6",
+                "LIBXML2_2.5.7",
+                "LIBXML2_2.5.8",
+                "LIBXML2_2.5.9",
+                "LIBXML2_2.6.0",
+                "LIBXML2_2.6.1",
+                "LIBXML2_2.6.2",
+                "LIBXML2_2.6.3",
+                "LIBXML2_2.6.5",
+                "LIBXML2_2.6.6",
+                "LIBXML2_2.6.7",
+                "LIBXML2_2.6.8",
+                "LIBXML2_2.6.10",
+                "LIBXML2_2.6.11",
+                "LIBXML2_2.6.12",
+                "LIBXML2_2.6.14",
+                "LIBXML2_2.6.15",
+                "LIBXML2_2.6.16",
+                "LIBXML2_2.6.17",
+                "LIBXML2_2.6.18",
+                "LIBXML2_2.6.19",
+                "LIBXML2_2.6.20",
+                "LIBXML2_2.6.21",
+                "LIBXML2_2.6.23",
+                "LIBXML2_2.6.24",
+                "LIBXML2_2.6.25",
+                "LIBXML2_2.6.27",
+                "LIBXML2_2.6.28",
+                "LIBXML2_2.6.29",
+                "LIBXML2_2.6.32",
+                "LIBXML2_2.7.0",
+                "LIBXML2_2.7.3",
+                "LIBXML2_2.7.4",
+                "LIBXML2_2.8.0",
+                "LIBXML2_2.9.0",
+                "LIBXML2_2.9.1",
+                "LIBXML2_2.9.8",
+                "LIBXML2_2.9.11"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libz.so.1"
+            ],
+            "name": "/usr/lib/libxml2.so.2"
+        },
+        {
+            "apiversions": [
+                "LIBXML2_2.4.30",
+                "LIBXML2_2.5.0",
+                "LIBXML2_2.5.2",
+                "LIBXML2_2.5.4",
+                "LIBXML2_2.5.5",
+                "LIBXML2_2.5.6",
+                "LIBXML2_2.5.7",
+                "LIBXML2_2.5.8",
+                "LIBXML2_2.5.9",
+                "LIBXML2_2.6.0",
+                "LIBXML2_2.6.1",
+                "LIBXML2_2.6.2",
+                "LIBXML2_2.6.3",
+                "LIBXML2_2.6.5",
+                "LIBXML2_2.6.6",
+                "LIBXML2_2.6.7",
+                "LIBXML2_2.6.8",
+                "LIBXML2_2.6.10",
+                "LIBXML2_2.6.11",
+                "LIBXML2_2.6.12",
+                "LIBXML2_2.6.14",
+                "LIBXML2_2.6.15",
+                "LIBXML2_2.6.16",
+                "LIBXML2_2.6.17",
+                "LIBXML2_2.6.18",
+                "LIBXML2_2.6.19",
+                "LIBXML2_2.6.20",
+                "LIBXML2_2.6.21",
+                "LIBXML2_2.6.23",
+                "LIBXML2_2.6.24",
+                "LIBXML2_2.6.25",
+                "LIBXML2_2.6.27",
+                "LIBXML2_2.6.28",
+                "LIBXML2_2.6.29",
+                "LIBXML2_2.6.32",
+                "LIBXML2_2.7.0",
+                "LIBXML2_2.7.3",
+                "LIBXML2_2.7.4",
+                "LIBXML2_2.8.0",
+                "LIBXML2_2.9.0",
+                "LIBXML2_2.9.1",
+                "LIBXML2_2.9.8",
+                "LIBXML2_2.9.11"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libz.so.1"
+            ],
+            "name": "/usr/lib/libxml2.so.2.9.14"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libxtables.so.12"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libxtables.so.12.4.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libyajl.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libyajl.so.2.1.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/librt.so.1",
+                "/usr/lib/libcrypt.so.2"
+            ],
+            "name": "/usr/lib/libzebra.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/librt.so.1",
+                "/usr/lib/libcrypt.so.2"
+            ],
+            "name": "/usr/lib/libzebra.so.1.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libzstd.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libzstd.so.1.5.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/mod_access.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/mod_accesslog.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/mod_alias.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/mod_auth.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcrypto.so.3"
+            ],
+            "name": "/usr/lib/mod_authn_file.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/mod_cgi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libpcre.so.1"
+            ],
+            "name": "/usr/lib/mod_dirlisting.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/mod_fastcgi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/mod_indexfile.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/mod_openssl.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/mod_proxy.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libpcre.so.1"
+            ],
+            "name": "/usr/lib/mod_redirect.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libpcre.so.1"
+            ],
+            "name": "/usr/lib/mod_rewrite.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcrypto.so.3"
+            ],
+            "name": "/usr/lib/mod_secdownload.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/mod_setenv.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/mod_ssi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/mod_staticfile.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcrypto.so.3"
+            ],
+            "name": "/usr/lib/ossl-modules/legacy.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/plugins/dobby/libIpcPlugin.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libsystemd.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/plugins/dobby/libLoggingPlugin.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/plugins/dobby/libMinidumpPlugin.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libnl-3.so.200",
+                "/usr/lib/libnl-route-3.so.200",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libyajl.so.2"
+            ],
+            "name": "/usr/lib/plugins/dobby/libNetworkingPlugin.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/plugins/dobby/libOOMCrashPlugin.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/plugins/dobby/libStoragePlugin.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_asyncio.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/python3.10/lib-dynload/_bisect.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_blake2.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libbz2.so.1"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_bz2.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_codecs_cn.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_codecs_hk.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_codecs_iso2022.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_codecs_jp.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_codecs_kr.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_codecs_tw.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/python3.10/lib-dynload/_contextvars.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcrypt.so.2"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_crypt.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/python3.10/lib-dynload/_csv.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libffi.so.8"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_ctypes.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_ctypes_test.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libncursesw.so.5",
+                "/lib/libtinfo.so.5"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_curses.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libpanelw.so.5"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_curses_panel.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_datetime.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgdbm_compat.so.3"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_dbm.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_decimal.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_elementtree.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcrypto.so.3"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_hashlib.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/python3.10/lib-dynload/_heapq.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/python3.10/lib-dynload/_json.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/python3.10/lib-dynload/_lsprof.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/liblzma.so.5"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_lzma.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_md5.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_multibytecodec.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_multiprocessing.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/python3.10/lib-dynload/_opcode.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_pickle.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_posixshmem.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_posixsubprocess.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/python3.10/lib-dynload/_queue.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_random.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_sha1.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_sha256.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_sha3.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_sha512.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_socket.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libsqlite3.so.0"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_sqlite3.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_ssl.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/python3.10/lib-dynload/_statistics.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_struct.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_testbuffer.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_testcapi.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/python3.10/lib-dynload/_testimportmultiple.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_testinternalcapi.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/python3.10/lib-dynload/_testmultiphase.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libuuid.so.1"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_uuid.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_xxsubinterpreters.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_xxtestfuzz.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_zoneinfo.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/array.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/audioop.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/binascii.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/cmath.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/fcntl.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/grp.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/math.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/mmap.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libnsl.so.3",
+                "/usr/lib/libtirpc.so.3"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/nis.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/ossaudiodev.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/pyexpat.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libreadline.so.5"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/readline.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/resource.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/select.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/spwd.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/syslog.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/termios.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/unicodedata.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/python3.10/lib-dynload/xxlimited.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/python3.10/lib-dynload/xxlimited_35.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/zlib.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libffi.so.8"
+            ],
+            "name": "/usr/lib/python3.10/site-packages/_cffi_backend.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/site-packages/bcrypt/_bcrypt.abi3.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/python3.10/site-packages/zope/interface/_zope_interface_coptimizations.cpython-310-aarch64-linux-gnu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0",
+                "/lib/libpam_misc.so.0",
+                "/usr/lib/libecryptfs.so.1",
+                "/usr/lib/libgcrypt.so.20",
+                "/usr/lib/libkeyutils.so.1"
+            ],
+            "name": "/usr/lib/security/pam_ecryptfs.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_DNAT.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_DNPT.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_HL.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_LOG.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_MASQUERADE.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_NETMAP.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_REDIRECT.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_REJECT.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_SNAT.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_SNPT.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_ah.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_dst.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_eui64.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_frag.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_hbh.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_hl.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_icmp6.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_ipv6header.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_mh.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_rt.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_srh.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libipt_CLUSTERIP.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libipt_DNAT.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libipt_ECN.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libipt_LOG.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libipt_MASQUERADE.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libipt_NETMAP.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libipt_REDIRECT.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libipt_REJECT.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libipt_SNAT.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libipt_TRIGGER.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libipt_TTL.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libipt_ULOG.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libipt_ah.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libipt_icmp.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libipt_realm.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libipt_ttl.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_AUDIT.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_CHECKSUM.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_CLASSIFY.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_CONNMARK.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_CONNSECMARK.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_CT.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_DSCP.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_HMARK.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_IDLETIMER.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_LED.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_MARK.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_NFLOG.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_NFQUEUE.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_NOTRACK.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_RATEEST.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_SECMARK.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_SET.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_SYNPROXY.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_TCPMSS.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_TCPOPTSTRIP.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_TEE.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_TOS.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_TPROXY.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_TRACE.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_addrtype.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_bpf.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_cgroup.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_cluster.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_comment.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_connbytes.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_connlimit.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_connmark.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_conntrack.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_cpu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_dccp.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_devgroup.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_dscp.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_ecn.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_esp.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_hashlimit.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_helper.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_ipcomp.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_iprange.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_ipvs.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_length.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_limit.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_mac.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_mark.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_multiport.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_nfacct.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_osf.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_owner.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_physdev.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_pkttype.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_policy.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_quota.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_rateest.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_recent.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_rpfilter.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_sctp.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_set.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_socket.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_standard.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_state.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_statistic.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_string.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_tcp.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_tcpmss.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_time.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_tos.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_u32.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_udp.so"
+        }
+    ]
+}

--- a/templates/generic/rpi4_reference_bb_kirkstone.json
+++ b/templates/generic/rpi4_reference_bb_kirkstone.json
@@ -1,0 +1,122 @@
+{
+    "platformName": "rpi4_reference",
+    "os": "linux",
+    "arch": {
+        "arch": "arm",
+        "variant": "v7"
+    },
+    "rdk": {
+        "version": "2024Q3",
+        "supportedFeatures": [
+            "DeviceInfo",
+            "org.rdk.Network",
+            "org.rdk.OCIContainer",
+            "org.rdk.Proxies"
+        ]
+    },
+    "hardware": {
+            "graphics":true
+    },
+    "storage": {
+        "persistent": {
+            "storageDir": "/opt/dac_apps/data/0",
+            "maxSize": "100M"
+        }
+    },
+    "gpu": {
+        "extraMounts": [
+            {
+                "source": "/etc/ssl/certs",
+                "destination": "/etc/ssl/certs",
+                "type": "bind",
+                "options": [
+                    "rbind",
+                    "nosuid",
+                    "nodev",
+                    "ro",
+                    "X-mount.mkdir"
+                ]
+            },
+            {
+                "source": "/usr/share/ca-certificates",
+                "destination": "/usr/share/ca-certificates",
+                "type": "bind",
+                "options": [
+                    "rbind",
+                    "nosuid",
+                    "nodev",
+                    "ro",
+                    "X-mount.mkdir"
+                ]
+            }
+        ],
+        "envvar": [
+            "XDG_RUNTIME_DIR=/tmp"
+        ],
+        "devs": [
+        ],
+        "gfxLibs": [
+        ]
+    },
+    "mounts": [
+        {
+            "source": "/usr/lib/libstdc++.so.6",
+            "destination": "/usr/lib/libstdc++.so.6",
+            "options": [
+                "rbind",
+                "nosuid",
+                "nodev",
+                "ro"
+            ],
+            "type": "bind"
+        },
+        {
+            "source": "/lib/libgcc_s.so.1",
+            "destination": "/lib/libgcc_s.so.1",
+            "options": [
+                "rbind",
+                "nosuid",
+                "nodev",
+                "ro"
+            ],
+            "type": "bind"
+        },
+        {
+            "source": "tmpfs",
+            "destination": "/tmp",
+            "options": [
+                "nosuid",
+                "strictatime",
+                "mode=755",
+                "size=65536k"
+            ],
+            "type": "tmpfs"
+        }
+    ],
+    "network": {
+        "options": [
+            "nat",
+            "open",
+            "private"
+        ]
+    },
+    "envvar": [
+    ],
+    "resourceLimits": [
+        {
+            "type": "RLIMIT_NPROC",
+            "hard": 300,
+            "soft": 300
+        },
+        {
+            "type": "RLIMIT_RTPRIO",
+            "hard": 6,
+            "soft": 6
+        }
+    ],
+    "disableUserNamespacing": true,
+    "logging": {
+        "mode": "file",
+        "logDir": "/var/log"
+    }
+}

--- a/templates/generic/rpi4_reference_bb_kirkstone_libs.json
+++ b/templates/generic/rpi4_reference_bb_kirkstone_libs.json
@@ -1,0 +1,9509 @@
+{
+    "libs": [
+        {
+            "apiversions": [
+                "GLIBC_2.4",
+                "GLIBC_2.34",
+                "GLIBC_2.35",
+                "GLIBC_PRIVATE"
+            ],
+            "deps": [],
+            "name": "/lib/ld-linux-armhf.so.3"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.4"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libBrokenLocale.so.1"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.4"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libanl.so.1"
+        },
+        {
+            "apiversions": [
+                "BLKID_1.0",
+                "BLKID_2.15",
+                "BLKID_2.17",
+                "BLKID_2.18",
+                "BLKID_2.20",
+                "BLKID_2.21",
+                "BLKID_2.23",
+                "BLKID_2.25",
+                "BLKID_2.30",
+                "BLKID_2_31",
+                "BLKID_2_36",
+                "BLKID_2_37"
+            ],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libblkid.so.1"
+        },
+        {
+            "apiversions": [
+                "BLKID_1.0",
+                "BLKID_2.15",
+                "BLKID_2.17",
+                "BLKID_2.18",
+                "BLKID_2.20",
+                "BLKID_2.21",
+                "BLKID_2.23",
+                "BLKID_2.25",
+                "BLKID_2.30",
+                "BLKID_2_31",
+                "BLKID_2_36",
+                "BLKID_2_37"
+            ],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libblkid.so.1.1.0"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.4",
+                "GLIBC_2.5",
+                "GLIBC_2.6",
+                "GLIBC_2.7",
+                "GLIBC_2.8",
+                "GLIBC_2.9",
+                "GLIBC_2.10",
+                "GLIBC_2.11",
+                "GLIBC_2.12",
+                "GLIBC_2.13",
+                "GLIBC_2.14",
+                "GLIBC_2.15",
+                "GLIBC_2.16",
+                "GLIBC_2.17",
+                "GLIBC_2.18",
+                "GLIBC_2.22",
+                "GLIBC_2.23",
+                "GLIBC_2.24",
+                "GLIBC_2.25",
+                "GLIBC_2.26",
+                "GLIBC_2.27",
+                "GLIBC_2.28",
+                "GLIBC_2.29",
+                "GLIBC_2.30",
+                "GLIBC_2.31",
+                "GLIBC_2.32",
+                "GLIBC_2.33",
+                "GLIBC_2.34",
+                "GLIBC_2.35",
+                "GLIBC_PRIVATE"
+            ],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3"
+            ],
+            "name": "/lib/libc.so.6"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.4",
+                "GLIBC_2.10",
+                "GLIBC_2.16",
+                "GLIBC_2.33"
+            ],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libc_malloc_debug.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libcap-ng.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libcap-ng.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libcap.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libcap.so.2.65"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libcom_err.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libcom_err.so.2.1"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.4"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libdl.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libe2p.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libe2p.so.2.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libcom_err.so.2"
+            ],
+            "name": "/lib/libext2fs.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libcom_err.so.2"
+            ],
+            "name": "/lib/libext2fs.so.2.4"
+        },
+        {
+            "apiversions": [
+                "FDISK_2.26",
+                "FDISK_2.27",
+                "FDISK_2.28",
+                "FDISK_2.29",
+                "FDISK_2.30",
+                "FDISK_2.31",
+                "FDISK_2.32",
+                "FDISK_2.33",
+                "FDISK_2.35",
+                "FDISK_2.36"
+            ],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libblkid.so.1",
+                "/lib/libc.so.6",
+                "/usr/lib/libuuid.so.1"
+            ],
+            "name": "/lib/libfdisk.so.1"
+        },
+        {
+            "apiversions": [
+                "FDISK_2.26",
+                "FDISK_2.27",
+                "FDISK_2.28",
+                "FDISK_2.29",
+                "FDISK_2.30",
+                "FDISK_2.31",
+                "FDISK_2.32",
+                "FDISK_2.33",
+                "FDISK_2.35",
+                "FDISK_2.36"
+            ],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libblkid.so.1",
+                "/lib/libc.so.6",
+                "/usr/lib/libuuid.so.1"
+            ],
+            "name": "/lib/libfdisk.so.1.1.0"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.0",
+                "GCC_3.0",
+                "GCC_3.3",
+                "GCC_3.3.1",
+                "GCC_3.3.4",
+                "GCC_3.4",
+                "GCC_3.4.2",
+                "GCC_4.0.0",
+                "GCC_4.2.0",
+                "GCC_4.3.0",
+                "GCC_4.7.0",
+                "GCC_7.0.0",
+                "GCC_3.5"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libgcc_s.so.1"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.4",
+                "GLIBC_2.15",
+                "GLIBC_2.18",
+                "GLIBC_2.23",
+                "GLIBC_2.24",
+                "GLIBC_2.25",
+                "GLIBC_2.27",
+                "GLIBC_2.28",
+                "GLIBC_2.29",
+                "GLIBC_2.31",
+                "GLIBC_2.32",
+                "GLIBC_2.35"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libm.so.6"
+        },
+        {
+            "apiversions": [
+                "MOUNT_2.19",
+                "MOUNT_2.20",
+                "MOUNT_2.21",
+                "MOUNT_2.22",
+                "MOUNT_2.23",
+                "MOUNT_2.24",
+                "MOUNT_2.25",
+                "MOUNT_2.26",
+                "MOUNT_2.28",
+                "MOUNT_2.30",
+                "MOUNT_2.33",
+                "MOUNT_2.34",
+                "MOUNT_2_35",
+                "MOUNT_2_37"
+            ],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libblkid.so.1",
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libmount.so.1"
+        },
+        {
+            "apiversions": [
+                "MOUNT_2.19",
+                "MOUNT_2.20",
+                "MOUNT_2.21",
+                "MOUNT_2.22",
+                "MOUNT_2.23",
+                "MOUNT_2.24",
+                "MOUNT_2.25",
+                "MOUNT_2.26",
+                "MOUNT_2.28",
+                "MOUNT_2.30",
+                "MOUNT_2.33",
+                "MOUNT_2.34",
+                "MOUNT_2_35",
+                "MOUNT_2_37"
+            ],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libblkid.so.1",
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libmount.so.1.1.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libtinfo.so.5"
+            ],
+            "name": "/lib/libncurses.so.5"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libtinfo.so.5"
+            ],
+            "name": "/lib/libncurses.so.5.9"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libtinfo.so.5"
+            ],
+            "name": "/lib/libncursesw.so.5"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libtinfo.so.5"
+            ],
+            "name": "/lib/libncursesw.so.5.9"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.4",
+                "GLIBC_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libnsl.so.1"
+        },
+        {
+            "apiversions": [
+                "GLIBC_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libnss_compat.so.2"
+        },
+        {
+            "apiversions": [
+                "GLIBC_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libnss_db.so.2"
+        },
+        {
+            "apiversions": [
+                "GLIBC_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libnss_dns.so.2"
+        },
+        {
+            "apiversions": [
+                "GLIBC_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libnss_files.so.2"
+        },
+        {
+            "apiversions": [
+                "GLIBC_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libresolv.so.2"
+            ],
+            "name": "/lib/libnss_hesiod.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libnss_myhostname.so.2"
+        },
+        {
+            "apiversions": [
+                "LIBPAM_1.0",
+                "LIBPAM_EXTENSION_1.0",
+                "LIBPAM_EXTENSION_1.1",
+                "LIBPAM_EXTENSION_1.1.1",
+                "LIBPAM_MODUTIL_1.0",
+                "LIBPAM_MODUTIL_1.1",
+                "LIBPAM_MODUTIL_1.1.3",
+                "LIBPAM_MODUTIL_1.1.9",
+                "LIBPAM_MODUTIL_1.3.2",
+                "LIBPAM_1.4",
+                "LIBPAM_MODUTIL_1.4.1"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libpam.so.0"
+        },
+        {
+            "apiversions": [
+                "LIBPAM_1.0",
+                "LIBPAM_EXTENSION_1.0",
+                "LIBPAM_EXTENSION_1.1",
+                "LIBPAM_EXTENSION_1.1.1",
+                "LIBPAM_MODUTIL_1.0",
+                "LIBPAM_MODUTIL_1.1",
+                "LIBPAM_MODUTIL_1.1.3",
+                "LIBPAM_MODUTIL_1.1.9",
+                "LIBPAM_MODUTIL_1.3.2",
+                "LIBPAM_1.4",
+                "LIBPAM_MODUTIL_1.4.1"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libpam.so.0.85.1"
+        },
+        {
+            "apiversions": [
+                "LIBPAM_MISC_1.0"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/libpam_misc.so.0"
+        },
+        {
+            "apiversions": [
+                "LIBPAM_MISC_1.0"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/libpam_misc.so.0.82.1"
+        },
+        {
+            "apiversions": [
+                "LIBPAMC_1.0"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libpamc.so.0"
+        },
+        {
+            "apiversions": [
+                "LIBPAMC_1.0"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libpamc.so.0.82.1"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.4",
+                "GLIBC_2.11",
+                "GLIBC_2.12",
+                "GLIBC_2.18",
+                "GLIBC_2.28",
+                "GLIBC_2.30",
+                "GLIBC_2.31"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libpthread.so.0"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.4",
+                "GLIBC_2.9",
+                "GLIBC_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libresolv.so.2"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.4",
+                "GLIBC_2.7"
+            ],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/librt.so.1"
+        },
+        {
+            "apiversions": [
+                "SMARTCOLS_2.25",
+                "SMARTCOLS_2.27",
+                "SMARTCOLS_2.28",
+                "SMARTCOLS_2.29",
+                "SMARTCOLS_2.30",
+                "SMARTCOLS_2.31",
+                "SMARTCOLS_2.33",
+                "SMARTCOLS_2.34",
+                "SMARTCOLS_2.35"
+            ],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libsmartcols.so.1"
+        },
+        {
+            "apiversions": [
+                "SMARTCOLS_2.25",
+                "SMARTCOLS_2.27",
+                "SMARTCOLS_2.28",
+                "SMARTCOLS_2.29",
+                "SMARTCOLS_2.30",
+                "SMARTCOLS_2.31",
+                "SMARTCOLS_2.33",
+                "SMARTCOLS_2.34",
+                "SMARTCOLS_2.35"
+            ],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libsmartcols.so.1.1.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libcom_err.so.2"
+            ],
+            "name": "/lib/libss.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libcom_err.so.2"
+            ],
+            "name": "/lib/libss.so.2.0"
+        },
+        {
+            "apiversions": [
+                "LIBSYSTEMD_209",
+                "LIBSYSTEMD_211",
+                "LIBSYSTEMD_213",
+                "LIBSYSTEMD_214",
+                "LIBSYSTEMD_216",
+                "LIBSYSTEMD_217",
+                "LIBSYSTEMD_219",
+                "LIBSYSTEMD_220",
+                "LIBSYSTEMD_221",
+                "LIBSYSTEMD_222",
+                "LIBSYSTEMD_226",
+                "LIBSYSTEMD_227",
+                "LIBSYSTEMD_229",
+                "LIBSYSTEMD_230",
+                "LIBSYSTEMD_231",
+                "LIBSYSTEMD_232",
+                "LIBSYSTEMD_233",
+                "LIBSYSTEMD_234",
+                "LIBSYSTEMD_236",
+                "LIBSYSTEMD_237",
+                "LIBSYSTEMD_238",
+                "LIBSYSTEMD_239",
+                "LIBSYSTEMD_240",
+                "LIBSYSTEMD_241",
+                "LIBSYSTEMD_243",
+                "LIBSYSTEMD_245",
+                "LIBSYSTEMD_246",
+                "LIBSYSTEMD_247",
+                "LIBSYSTEMD_248",
+                "LIBSYSTEMD_249",
+                "LIBSYSTEMD_250"
+            ],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6",
+                "/lib/libcap.so.2",
+                "/usr/lib/libzstd.so.1"
+            ],
+            "name": "/lib/libsystemd.so.0"
+        },
+        {
+            "apiversions": [
+                "LIBSYSTEMD_209",
+                "LIBSYSTEMD_211",
+                "LIBSYSTEMD_213",
+                "LIBSYSTEMD_214",
+                "LIBSYSTEMD_216",
+                "LIBSYSTEMD_217",
+                "LIBSYSTEMD_219",
+                "LIBSYSTEMD_220",
+                "LIBSYSTEMD_221",
+                "LIBSYSTEMD_222",
+                "LIBSYSTEMD_226",
+                "LIBSYSTEMD_227",
+                "LIBSYSTEMD_229",
+                "LIBSYSTEMD_230",
+                "LIBSYSTEMD_231",
+                "LIBSYSTEMD_232",
+                "LIBSYSTEMD_233",
+                "LIBSYSTEMD_234",
+                "LIBSYSTEMD_236",
+                "LIBSYSTEMD_237",
+                "LIBSYSTEMD_238",
+                "LIBSYSTEMD_239",
+                "LIBSYSTEMD_240",
+                "LIBSYSTEMD_241",
+                "LIBSYSTEMD_243",
+                "LIBSYSTEMD_245",
+                "LIBSYSTEMD_246",
+                "LIBSYSTEMD_247",
+                "LIBSYSTEMD_248",
+                "LIBSYSTEMD_249",
+                "LIBSYSTEMD_250"
+            ],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6",
+                "/lib/libcap.so.2",
+                "/usr/lib/libzstd.so.1"
+            ],
+            "name": "/lib/libsystemd.so.0.33.0"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.4"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libthread_db.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libtinfo.so.5"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libtinfo.so.5.9"
+        },
+        {
+            "apiversions": [
+                "LIBUDEV_183",
+                "LIBUDEV_189",
+                "LIBUDEV_196",
+                "LIBUDEV_199",
+                "LIBUDEV_215",
+                "LIBUDEV_247"
+            ],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libudev.so.1"
+        },
+        {
+            "apiversions": [
+                "LIBUDEV_183",
+                "LIBUDEV_189",
+                "LIBUDEV_196",
+                "LIBUDEV_199",
+                "LIBUDEV_215",
+                "LIBUDEV_247"
+            ],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libudev.so.1.7.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6",
+                "/lib/libudev.so.1",
+                "/usr/lib/libatomic.so.1"
+            ],
+            "name": "/lib/libusb-1.0.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6",
+                "/lib/libudev.so.1",
+                "/usr/lib/libatomic.so.1"
+            ],
+            "name": "/lib/libusb-1.0.so.0.3.0"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.4"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libutil.so.1"
+        },
+        {
+            "apiversions": [
+                "ZLIB_1.2.0",
+                "ZLIB_1.2.0.2",
+                "ZLIB_1.2.0.8",
+                "ZLIB_1.2.2",
+                "ZLIB_1.2.2.3",
+                "ZLIB_1.2.2.4",
+                "ZLIB_1.2.3.3",
+                "ZLIB_1.2.3.4",
+                "ZLIB_1.2.3.5",
+                "ZLIB_1.2.5.1",
+                "ZLIB_1.2.5.2",
+                "ZLIB_1.2.7.1",
+                "ZLIB_1.2.9"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libz.so.1"
+        },
+        {
+            "apiversions": [
+                "ZLIB_1.2.0",
+                "ZLIB_1.2.0.2",
+                "ZLIB_1.2.0.8",
+                "ZLIB_1.2.2",
+                "ZLIB_1.2.2.3",
+                "ZLIB_1.2.2.4",
+                "ZLIB_1.2.3.3",
+                "ZLIB_1.2.3.4",
+                "ZLIB_1.2.3.5",
+                "ZLIB_1.2.5.1",
+                "ZLIB_1.2.5.2",
+                "ZLIB_1.2.7.1",
+                "ZLIB_1.2.9"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/lib/libz.so.1.2.11"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libcap.so.2",
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/security/pam_cap.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/security/pam_deny.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/security/pam_env.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/security/pam_faildelay.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/security/pam_group.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/security/pam_lastlog.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/security/pam_limits.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/security/pam_mail.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/security/pam_motd.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/security/pam_nologin.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/security/pam_permit.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/security/pam_rootok.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/security/pam_securetty.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/security/pam_shells.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0",
+                "/usr/lib/libcrypt.so.2"
+            ],
+            "name": "/lib/security/pam_unix.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libpam.so.0"
+            ],
+            "name": "/lib/security/pam_warn.so"
+        },
+        {
+            "apiversions": [
+                "SD_SHARED"
+            ],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libblkid.so.1",
+                "/lib/libc.so.6",
+                "/lib/libcap.so.2",
+                "/lib/libm.so.6",
+                "/lib/libmount.so.1",
+                "/usr/lib/libcrypt.so.2",
+                "/usr/lib/libkmod.so.2",
+                "/usr/lib/libzstd.so.1"
+            ],
+            "name": "/lib/systemd/libsystemd-shared-250.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-altair-lte.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-anydata.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-broadmobi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-cinterion.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-dell.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-dlink.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-ericsson-mbm.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-fibocom.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-foxconn.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-generic.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-gosuncn.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-haier.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-huawei.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-iridium.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-linktop.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-longcheer.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-motorola.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-mtk.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-nokia-icera.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-nokia.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-novatel-lte.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-novatel.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-option-hso.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-option.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-pantech.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-qcom-soc.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-quectel.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-samsung.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-sierra-legacy.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-sierra.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-simtech.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-telit.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-thuraya.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-tplink.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-ublox.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-via.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-wavecom.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-x22x.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-plugin-zte.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0",
+                "/usr/lib/libqmi-glib.so.5"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-shared-foxconn.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-shared-icera.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-shared-novatel.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-shared-option.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-shared-sierra.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-shared-telit.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmm-glib.so.0"
+            ],
+            "name": "/usr/lib/ModemManager/libmm-shared-xmm.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/usr/lib/libgcrypt.so.20"
+            ],
+            "name": "/usr/lib/crda/libreg.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libgcrypt.so.20"
+            ],
+            "name": "/usr/lib/ecryptfs/libecryptfs_key_mod_openssl.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgcrypt.so.20"
+            ],
+            "name": "/usr/lib/ecryptfs/libecryptfs_key_mod_passphrase.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/gio/modules/libgioenvironmentproxy.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/gio/modules/libgioopenssl.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libunwind.so.8"
+            ],
+            "name": "/usr/lib/heaptrack/libheaptrack_inject.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libunwind.so.8"
+            ],
+            "name": "/usr/lib/heaptrack/libheaptrack_preload.so"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.4"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libBrokenLocale.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libavro.so.23",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcimplog.so.1.0.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_wifi.so.0",
+                "/usr/lib/liblibparodus.so",
+                "/usr/lib/liblog4c.so.3",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbuscore.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/librtMessage.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libuuid.so.1",
+                "/usr/lib/libwrp-c.so"
+            ],
+            "name": "/usr/lib/libHarvesterSsp.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libavro.so.23",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcimplog.so.1.0.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_wifi.so.0",
+                "/usr/lib/liblibparodus.so",
+                "/usr/lib/liblog4c.so.3",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbuscore.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/librtMessage.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libuuid.so.1",
+                "/usr/lib/libwrp-c.so"
+            ],
+            "name": "/usr/lib/libHarvesterSsp.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libavro.so.23",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcimplog.so.1.0.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_wifi.so.0",
+                "/usr/lib/liblibparodus.so",
+                "/usr/lib/liblog4c.so.3",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbuscore.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/librtMessage.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libuuid.so.1",
+                "/usr/lib/libwrp-c.so"
+            ],
+            "name": "/usr/lib/libHarvesterSsp.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/libz.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libjansson.so.4",
+                "/usr/lib/liblmapi.so.0",
+                "/usr/lib/libnetfilter_queue.so.1",
+                "/usr/lib/libnfnetlink.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libulog.so.0"
+            ],
+            "name": "/usr/lib/libHotspotApi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/libz.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libjansson.so.4",
+                "/usr/lib/liblmapi.so.0",
+                "/usr/lib/libnetfilter_queue.so.1",
+                "/usr/lib/libnfnetlink.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libulog.so.0"
+            ],
+            "name": "/usr/lib/libHotspotApi.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/libz.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libjansson.so.4",
+                "/usr/lib/liblmapi.so.0",
+                "/usr/lib/libnetfilter_queue.so.1",
+                "/usr/lib/libnfnetlink.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libulog.so.0"
+            ],
+            "name": "/usr/lib/libHotspotApi.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libXmeshDiags.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/liblibparodus.so",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprint_uptime.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libulog.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libwebconfig_framework.so.0",
+                "/usr/lib/libwrp-c.so"
+            ],
+            "name": "/usr/lib/libMeshAgentSsp.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libXmeshDiags.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/liblibparodus.so",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprint_uptime.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libulog.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libwebconfig_framework.so.0",
+                "/usr/lib/libwrp-c.so"
+            ],
+            "name": "/usr/lib/libMeshAgentSsp.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libXmeshDiags.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/liblibparodus.so",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprint_uptime.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libulog.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libwebconfig_framework.so.0",
+                "/usr/lib/libwrp-c.so"
+            ],
+            "name": "/usr/lib/libMeshAgentSsp.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libOvsAgentSsp.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0"
+            ],
+            "name": "/usr/lib/libOvsAction.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libOvsAgentSsp.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0"
+            ],
+            "name": "/usr/lib/libOvsAction.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libOvsAgentSsp.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0"
+            ],
+            "name": "/usr/lib/libOvsAction.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libOvsDbApi.so.0",
+                "/usr/lib/libjansson.so.4",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0"
+            ],
+            "name": "/usr/lib/libOvsAgentApi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libOvsDbApi.so.0",
+                "/usr/lib/libjansson.so.4",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0"
+            ],
+            "name": "/usr/lib/libOvsAgentApi.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libOvsDbApi.so.0",
+                "/usr/lib/libjansson.so.4",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0"
+            ],
+            "name": "/usr/lib/libOvsAgentApi.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0"
+            ],
+            "name": "/usr/lib/libOvsAgentSsp.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0"
+            ],
+            "name": "/usr/lib/libOvsAgentSsp.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0"
+            ],
+            "name": "/usr/lib/libOvsAgentSsp.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libjansson.so.4",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0"
+            ],
+            "name": "/usr/lib/libOvsDbApi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libjansson.so.4",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0"
+            ],
+            "name": "/usr/lib/libOvsDbApi.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libjansson.so.4",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0"
+            ],
+            "name": "/usr/lib/libOvsDbApi.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libbulkdata.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libccspinterface.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libdcautil.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libhttp.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbusmethod.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libreportgen.so.0",
+                "/usr/lib/libscheduler.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2parser.so.0",
+                "/usr/lib/libt2utils.so.0",
+                "/usr/lib/libwebconfig_framework.so.0",
+                "/usr/lib/libxconfclient.so.0"
+            ],
+            "name": "/usr/lib/libT2_tr181.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libbulkdata.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libccspinterface.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libdcautil.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libhttp.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbusmethod.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libreportgen.so.0",
+                "/usr/lib/libscheduler.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2parser.so.0",
+                "/usr/lib/libt2utils.so.0",
+                "/usr/lib/libwebconfig_framework.so.0",
+                "/usr/lib/libxconfclient.so.0"
+            ],
+            "name": "/usr/lib/libT2_tr181.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libbulkdata.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libccspinterface.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libdcautil.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libhttp.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbusmethod.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libreportgen.so.0",
+                "/usr/lib/libscheduler.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2parser.so.0",
+                "/usr/lib/libt2utils.so.0",
+                "/usr/lib/libwebconfig_framework.so.0",
+                "/usr/lib/libxconfclient.so.0"
+            ],
+            "name": "/usr/lib/libT2_tr181.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/liblibparodus.so",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libwrp-c.so"
+            ],
+            "name": "/usr/lib/libXmeshDiags.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/liblibparodus.so",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libwrp-c.so"
+            ],
+            "name": "/usr/lib/libXmeshDiags.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/liblibparodus.so",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libwrp-c.so"
+            ],
+            "name": "/usr/lib/libXmeshDiags.so.0.0.0"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.4"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libanl.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libapi_dhcpv4c.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libapi_dhcpv4c.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libapm.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libapm.so.1.0.0"
+        },
+        {
+            "apiversions": [
+                "LIBATOMIC_1.0",
+                "LIBATOMIC_1.1",
+                "LIBATOMIC_1.2"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libatomic.so.1"
+        },
+        {
+            "apiversions": [
+                "LIBATOMIC_1.0",
+                "LIBATOMIC_1.1",
+                "LIBATOMIC_1.2"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libatomic.so.1.2.0"
+        },
+        {
+            "apiversions": [
+                "ATTR_1.0",
+                "ATTR_1.1",
+                "ATTR_1.2",
+                "ATTR_1.3"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libattr.so.1"
+        },
+        {
+            "apiversions": [
+                "ATTR_1.0",
+                "ATTR_1.1",
+                "ATTR_1.2",
+                "ATTR_1.3"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libattr.so.1.1.2501"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1",
+                "/usr/lib/libjansson.so.4",
+                "/usr/lib/liblzma.so.5"
+            ],
+            "name": "/usr/lib/libavro.so.23"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1",
+                "/usr/lib/libjansson.so.4",
+                "/usr/lib/liblzma.so.5"
+            ],
+            "name": "/usr/lib/libavro.so.23.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libbluetooth.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libbluetooth.so.3.19.8"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libbreakpadwrapper.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libbreakpadwrapper.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libccspinterface.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libdcautil.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libhttp.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbusmethod.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libreportgen.so.0",
+                "/usr/lib/libscheduler.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2parser.so.0",
+                "/usr/lib/libt2utils.so.0",
+                "/usr/lib/libwebconfig_framework.so.0",
+                "/usr/lib/libxconfclient.so.0"
+            ],
+            "name": "/usr/lib/libbulkdata.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libccspinterface.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libdcautil.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libhttp.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbusmethod.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libreportgen.so.0",
+                "/usr/lib/libscheduler.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2parser.so.0",
+                "/usr/lib/libt2utils.so.0",
+                "/usr/lib/libwebconfig_framework.so.0",
+                "/usr/lib/libxconfclient.so.0"
+            ],
+            "name": "/usr/lib/libbulkdata.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libccspinterface.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libdcautil.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libhttp.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbusmethod.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libreportgen.so.0",
+                "/usr/lib/libscheduler.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2parser.so.0",
+                "/usr/lib/libt2utils.so.0",
+                "/usr/lib/libwebconfig_framework.so.0",
+                "/usr/lib/libxconfclient.so.0"
+            ],
+            "name": "/usr/lib/libbulkdata.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libbz2.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libbz2.so.1.0.8"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.4",
+                "GLIBC_2.10",
+                "GLIBC_2.16",
+                "GLIBC_2.33"
+            ],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libc_malloc_debug.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libcares.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libcares.so.2.5.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbuscore.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/librtMessage.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libssl.so.3",
+                "/usr/lib/libtrower-base64.so.1.0.0"
+            ],
+            "name": "/usr/lib/libccsp_common.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbuscore.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/librtMessage.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libssl.so.3",
+                "/usr/lib/libtrower-base64.so.1.0.0"
+            ],
+            "name": "/usr/lib/libccsp_common.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbuscore.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/librtMessage.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libssl.so.3",
+                "/usr/lib/libtrower-base64.so.1.0.0"
+            ],
+            "name": "/usr/lib/libccsp_common.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libccspinterface.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libccspinterface.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libccspinterface.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/librdkloggers.so.0"
+            ],
+            "name": "/usr/lib/libcimplog.so.1.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libcjson.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libcjson.so.1.7.15"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcjson.so.1"
+            ],
+            "name": "/usr/lib/libcjson_utils.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcjson.so.1"
+            ],
+            "name": "/usr/lib/libcjson_utils.so.1.7.15"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libtrower-base64.so.1.0.0"
+            ],
+            "name": "/usr/lib/libcjwt.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libcm_mgnt.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libcm_mgnt.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcimplog.so.1.0.0",
+                "/usr/lib/libcm_mgnt.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libulog.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libwebconfig_framework.so.0"
+            ],
+            "name": "/usr/lib/libcm_tr181.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcimplog.so.1.0.0",
+                "/usr/lib/libcm_mgnt.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libulog.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libwebconfig_framework.so.0"
+            ],
+            "name": "/usr/lib/libcm_tr181.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcimplog.so.1.0.0",
+                "/usr/lib/libcm_mgnt.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libulog.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libwebconfig_framework.so.0"
+            ],
+            "name": "/usr/lib/libcm_tr181.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcimplog.so.1.0.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/libwdmp-c.so"
+            ],
+            "name": "/usr/lib/libcpeabs.so"
+        },
+        {
+            "apiversions": [
+                "XCRYPT_2.0",
+                "XCRYPT_4.3",
+                "XCRYPT_4.4"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libcrypt.so.2"
+        },
+        {
+            "apiversions": [
+                "XCRYPT_2.0",
+                "XCRYPT_4.3",
+                "XCRYPT_4.4"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libcrypt.so.2.0.0"
+        },
+        {
+            "apiversions": [
+                "OPENSSL_3.0.0",
+                "OPENSSL_3.0.3"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libcrypto.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libidn2.so.0",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/libcurl.so.4"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libidn2.so.0",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/libcurl.so.4.7.0"
+        },
+        {
+            "apiversions": [
+                "LIBDBUS_1_3",
+                "LIBDBUS_PRIVATE_1.14.0"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libsystemd.so.0"
+            ],
+            "name": "/usr/lib/libdbus-1.so.3"
+        },
+        {
+            "apiversions": [
+                "LIBDBUS_1_3",
+                "LIBDBUS_PRIVATE_1.14.0"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libsystemd.so.0"
+            ],
+            "name": "/usr/lib/libdbus-1.so.3.32.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libccspinterface.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2utils.so.0"
+            ],
+            "name": "/usr/lib/libdcautil.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libccspinterface.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2utils.so.0"
+            ],
+            "name": "/usr/lib/libdcautil.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libccspinterface.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2utils.so.0"
+            ],
+            "name": "/usr/lib/libdcautil.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0"
+            ],
+            "name": "/usr/lib/libdhcp_client_utils.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0"
+            ],
+            "name": "/usr/lib/libdhcp_client_utils.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0"
+            ],
+            "name": "/usr/lib/libdhcp_client_utils.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libdiagnostic.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libdiagnostic.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libdiagnostic.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcm_mgnt.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libwebconfig_framework.so.0"
+            ],
+            "name": "/usr/lib/libdmlasecurity.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcm_mgnt.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libwebconfig_framework.so.0"
+            ],
+            "name": "/usr/lib/libdmlasecurity.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcm_mgnt.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libwebconfig_framework.so.0"
+            ],
+            "name": "/usr/lib/libdmlasecurity.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/libresolv.so.2",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libev.so.4",
+                "/usr/lib/libpcap.so.1",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0"
+            ],
+            "name": "/usr/lib/libdmltad.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/libresolv.so.2",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libev.so.4",
+                "/usr/lib/libpcap.so.1",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0"
+            ],
+            "name": "/usr/lib/libdmltad.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/libresolv.so.2",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libev.so.4",
+                "/usr/lib/libpcap.so.1",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0"
+            ],
+            "name": "/usr/lib/libdmltad.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libglog.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libwebconfig_framework.so.0"
+            ],
+            "name": "/usr/lib/libdmlxdns.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libglog.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libwebconfig_framework.so.0"
+            ],
+            "name": "/usr/lib/libdmlxdns.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libglog.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libwebconfig_framework.so.0"
+            ],
+            "name": "/usr/lib/libdmlxdns.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libdrop_ambient.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libdrop_ambient.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libebtc.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libebtc.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgcrypt.so.20",
+                "/usr/lib/libkeyutils.so.1"
+            ],
+            "name": "/usr/lib/libecryptfs.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgcrypt.so.20",
+                "/usr/lib/libkeyutils.so.1"
+            ],
+            "name": "/usr/lib/libecryptfs.so.1.0.0"
+        },
+        {
+            "apiversions": [
+                "ELFUTILS_1.0",
+                "ELFUTILS_1.1",
+                "ELFUTILS_1.1.1",
+                "ELFUTILS_1.2",
+                "ELFUTILS_1.3",
+                "ELFUTILS_1.4",
+                "ELFUTILS_1.5",
+                "ELFUTILS_1.6",
+                "ELFUTILS_1.7"
+            ],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6",
+                "/lib/libz.so.1"
+            ],
+            "name": "/usr/lib/libelf-0.186.so"
+        },
+        {
+            "apiversions": [
+                "ELFUTILS_1.0",
+                "ELFUTILS_1.1",
+                "ELFUTILS_1.1.1",
+                "ELFUTILS_1.2",
+                "ELFUTILS_1.3",
+                "ELFUTILS_1.4",
+                "ELFUTILS_1.5",
+                "ELFUTILS_1.6",
+                "ELFUTILS_1.7"
+            ],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6",
+                "/lib/libz.so.1"
+            ],
+            "name": "/usr/lib/libelf.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcm_mgnt.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_pon.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsyscfg.so.0"
+            ],
+            "name": "/usr/lib/libepon_tr181.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcm_mgnt.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_pon.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsyscfg.so.0"
+            ],
+            "name": "/usr/lib/libepon_tr181.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcm_mgnt.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_pon.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsyscfg.so.0"
+            ],
+            "name": "/usr/lib/libepon_tr181.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6"
+            ],
+            "name": "/usr/lib/libev.so.4"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6"
+            ],
+            "name": "/usr/lib/libev.so.4.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libevent-2.1.so.7"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libevent-2.1.so.7.0.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libexpat.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libexpat.so.1.8.9"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6",
+                "/usr/lib/libfcgi.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libfcgi++.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6",
+                "/usr/lib/libfcgi.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libfcgi++.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libfcgi.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libfcgi.so.0.0.0"
+        },
+        {
+            "apiversions": [
+                "LIBFFI_BASE_8.0",
+                "LIBFFI_COMPLEX_8.0",
+                "LIBFFI_CLOSURE_8.0",
+                "LIBFFI_GO_CLOSURE_8.0"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1"
+            ],
+            "name": "/usr/lib/libffi.so.8"
+        },
+        {
+            "apiversions": [
+                "LIBFFI_BASE_8.0",
+                "LIBFFI_COMPLEX_8.0",
+                "LIBFFI_CLOSURE_8.0",
+                "LIBFFI_GO_CLOSURE_8.0"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1"
+            ],
+            "name": "/usr/lib/libffi.so.8.1.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/librt.so.1",
+                "/usr/lib/libcrypt.so.2"
+            ],
+            "name": "/usr/lib/libfpm_pb.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/librt.so.1",
+                "/usr/lib/libcrypt.so.2"
+            ],
+            "name": "/usr/lib/libfpm_pb.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libfw_upgrade.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libfw_upgrade.so.0.0.0"
+        },
+        {
+            "apiversions": [
+                "GCRYPT_1.6"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libcap.so.2",
+                "/usr/lib/libgpg-error.so.0"
+            ],
+            "name": "/usr/lib/libgcrypt.so.20"
+        },
+        {
+            "apiversions": [
+                "GCRYPT_1.6"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libcap.so.2",
+                "/usr/lib/libgpg-error.so.0"
+            ],
+            "name": "/usr/lib/libgcrypt.so.20.3.4"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libgdbm.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libgdbm.so.3.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libgdbm_compat.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libgdbm_compat.so.3.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libmount.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgmodule-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/libgio-2.0.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libmount.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgmodule-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/libgio-2.0.so.0.7400.6"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libpcre2-8.so.0"
+            ],
+            "name": "/usr/lib/libglib-2.0.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libpcre2-8.so.0"
+            ],
+            "name": "/usr/lib/libglib-2.0.so.0.7400.6"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libunwind.so.8"
+            ],
+            "name": "/usr/lib/libglog.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libunwind.so.8"
+            ],
+            "name": "/usr/lib/libglog.so.0.5.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libglib-2.0.so.0"
+            ],
+            "name": "/usr/lib/libgmodule-2.0.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libglib-2.0.so.0"
+            ],
+            "name": "/usr/lib/libgmodule-2.0.so.0.7400.6"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libgmp.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libgmp.so.3.4.1"
+        },
+        {
+            "apiversions": [
+                "GNUTLS_1_4",
+                "GNUTLS_2_8",
+                "GNUTLS_2_10",
+                "GNUTLS_2_12",
+                "GNUTLS_3_0_0",
+                "GNUTLS_3_1_0",
+                "GNUTLS_FIPS140",
+                "GNUTLS_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1",
+                "/usr/lib/libgmp.so.3",
+                "/usr/lib/libhogweed.so.2",
+                "/usr/lib/libnettle.so.4"
+            ],
+            "name": "/usr/lib/libgnutls.so.28"
+        },
+        {
+            "apiversions": [
+                "GNUTLS_1_4",
+                "GNUTLS_2_8",
+                "GNUTLS_2_10",
+                "GNUTLS_2_12",
+                "GNUTLS_3_0_0",
+                "GNUTLS_3_1_0",
+                "GNUTLS_FIPS140",
+                "GNUTLS_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1",
+                "/usr/lib/libgmp.so.3",
+                "/usr/lib/libhogweed.so.2",
+                "/usr/lib/libnettle.so.4"
+            ],
+            "name": "/usr/lib/libgnutls.so.28.43.4"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libffi.so.8",
+                "/usr/lib/libglib-2.0.so.0"
+            ],
+            "name": "/usr/lib/libgobject-2.0.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libffi.so.8",
+                "/usr/lib/libglib-2.0.so.0"
+            ],
+            "name": "/usr/lib/libgobject-2.0.so.0.7400.6"
+        },
+        {
+            "apiversions": [
+                "GPG_ERROR_1.0"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libgpg-error.so.0"
+        },
+        {
+            "apiversions": [
+                "GPG_ERROR_1.0"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libgpg-error.so.0.32.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libsoup-2.4.so.1"
+            ],
+            "name": "/usr/lib/libgssdp-1.2.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libsoup-2.4.so.1"
+            ],
+            "name": "/usr/lib/libgssdp-1.2.so.0.104.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0"
+            ],
+            "name": "/usr/lib/libgthread-2.0.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libglib-2.0.so.0"
+            ],
+            "name": "/usr/lib/libgthread-2.0.so.0.7400.6"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libudev.so.1",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/libgudev-1.0.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libudev.so.1",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/libgudev-1.0.so.0.3.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgmodule-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libgssdp-1.2.so.0",
+                "/usr/lib/libsoup-2.4.so.1",
+                "/usr/lib/libuuid.so.1",
+                "/usr/lib/libxml2.so.2"
+            ],
+            "name": "/usr/lib/libgupnp-1.0.so.4"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgmodule-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libgssdp-1.2.so.0",
+                "/usr/lib/libsoup-2.4.so.1",
+                "/usr/lib/libuuid.so.1",
+                "/usr/lib/libxml2.so.2"
+            ],
+            "name": "/usr/lib/libgupnp-1.0.so.4.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0"
+            ],
+            "name": "/usr/lib/libhal_ethsw.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0"
+            ],
+            "name": "/usr/lib/libhal_ethsw.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libhal_moca.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libhal_moca.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/libhal_msomgmt.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/libhal_msomgmt.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libhal_mta.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libhal_mta.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libhal_platform.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libhal_platform.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/libhal_pon.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/libhal_pon.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libhal_vlan.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libhal_vlan.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libev.so.4",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libwpa_client.so"
+            ],
+            "name": "/usr/lib/libhal_wifi.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libev.so.4",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libwpa_client.so"
+            ],
+            "name": "/usr/lib/libhal_wifi.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libhistory.so.5"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libhistory.so.5.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgmp.so.3",
+                "/usr/lib/libnettle.so.4"
+            ],
+            "name": "/usr/lib/libhogweed.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgmp.so.3",
+                "/usr/lib/libnettle.so.4"
+            ],
+            "name": "/usr/lib/libhogweed.so.2.5"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/libhostap.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/libhostap.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libhttp.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libhttp.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libhttp.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libical.so.3"
+            ],
+            "name": "/usr/lib/libical-glib.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libical.so.3"
+            ],
+            "name": "/usr/lib/libical-glib.so.3.0.14"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libicui18n.so.70",
+                "/usr/lib/libicuuc.so.70"
+            ],
+            "name": "/usr/lib/libical.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libicui18n.so.70",
+                "/usr/lib/libicuuc.so.70"
+            ],
+            "name": "/usr/lib/libical.so.3.0.14"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libical.so.3",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libical_cxx.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libical.so.3",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libical_cxx.so.3.0.14"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libical.so.3"
+            ],
+            "name": "/usr/lib/libicalss.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libical.so.3"
+            ],
+            "name": "/usr/lib/libicalss.so.3.0.14"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libical.so.3",
+                "/usr/lib/libical_cxx.so.3",
+                "/usr/lib/libicalss.so.3",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libicalss_cxx.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libical.so.3",
+                "/usr/lib/libical_cxx.so.3",
+                "/usr/lib/libicalss.so.3",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libicalss_cxx.so.3.0.14"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libical.so.3"
+            ],
+            "name": "/usr/lib/libicalvcal.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libical.so.3"
+            ],
+            "name": "/usr/lib/libicalvcal.so.3.0.14"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libicudata.so.70"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libicudata.so.70.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libicudata.so.70",
+                "/usr/lib/libicuuc.so.70",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libicui18n.so.70"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libicudata.so.70",
+                "/usr/lib/libicuuc.so.70",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libicui18n.so.70.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libicudata.so.70",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libicuuc.so.70"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libicudata.so.70",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libicuuc.so.70.1"
+        },
+        {
+            "apiversions": [
+                "IDN2_0.0.0",
+                "IDN2_2.1.0"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libunistring.so.2"
+            ],
+            "name": "/usr/lib/libidn2.so.0"
+        },
+        {
+            "apiversions": [
+                "IDN2_0.0.0",
+                "IDN2_2.1.0"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libunistring.so.2"
+            ],
+            "name": "/usr/lib/libidn2.so.0.3.7"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libmbedcrypto.so.3",
+                "/usr/lib/libmbedtls.so.12",
+                "/usr/lib/libmbedx509.so.0"
+            ],
+            "name": "/usr/lib/libiksemel.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libmbedcrypto.so.3",
+                "/usr/lib/libmbedtls.so.12",
+                "/usr/lib/libmbedx509.so.0"
+            ],
+            "name": "/usr/lib/libiksemel.so.3.1.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libinterChipHelper.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libinterChipHelper.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libinterChipHelper.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libip4tc.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libip4tc.so.2.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libip6tc.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libip6tc.so.2.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libixml.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libixml.so.2.0.8"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libjansson.so.4"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libjansson.so.4.13.0"
+        },
+        {
+            "apiversions": [
+                "JSONC_PRIVATE",
+                "JSONC_0.14",
+                "JSONC_0.15"
+            ],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libjson-c.so.5"
+        },
+        {
+            "apiversions": [
+                "JSONC_PRIVATE",
+                "JSONC_0.14",
+                "JSONC_0.15"
+            ],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libjson-c.so.5.1.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libjson-c.so.5"
+            ],
+            "name": "/usr/lib/libjson_hal_client.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libjson-c.so.5"
+            ],
+            "name": "/usr/lib/libjson_hal_client.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libjson-c.so.5"
+            ],
+            "name": "/usr/lib/libjson_hal_server.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libjson-c.so.5"
+            ],
+            "name": "/usr/lib/libjson_hal_server.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libnlohmann_json_schema_validator.so.1",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libjson_schema_validator_wrapper.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libnlohmann_json_schema_validator.so.1",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libjson_schema_validator_wrapper.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libjsoncpp.so.1.9.5"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libjsoncpp.so.25"
+        },
+        {
+            "apiversions": [
+                "KEYUTILS_0.3",
+                "KEYUTILS_1.0",
+                "KEYUTILS_1.3",
+                "KEYUTILS_1.4",
+                "KEYUTILS_1.5",
+                "KEYUTILS_1.6",
+                "KEYUTILS_1.7",
+                "KEYUTILS_1.8",
+                "KEYUTILS_1.9"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libkeyutils.so.1"
+        },
+        {
+            "apiversions": [
+                "KEYUTILS_0.3",
+                "KEYUTILS_1.0",
+                "KEYUTILS_1.3",
+                "KEYUTILS_1.4",
+                "KEYUTILS_1.5",
+                "KEYUTILS_1.6",
+                "KEYUTILS_1.7",
+                "KEYUTILS_1.8",
+                "KEYUTILS_1.9"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libkeyutils.so.1.9"
+        },
+        {
+            "apiversions": [
+                "LIBKMOD_5",
+                "LIBKMOD_6",
+                "LIBKMOD_22"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1",
+                "/usr/lib/liblzma.so.5"
+            ],
+            "name": "/usr/lib/libkmod.so.2"
+        },
+        {
+            "apiversions": [
+                "LIBKMOD_5",
+                "LIBKMOD_6",
+                "LIBKMOD_22"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1",
+                "/usr/lib/liblzma.so.5"
+            ],
+            "name": "/usr/lib/libkmod.so.2.3.7"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libwrp-c.so"
+            ],
+            "name": "/usr/lib/liblibparodus.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcimplog.so.1.0.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/libwrp-c.so"
+            ],
+            "name": "/usr/lib/liblibseshat.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/liblinenoise.so.1.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbuscore.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/librtMessage.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libxml2.so.2"
+            ],
+            "name": "/usr/lib/liblmapi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbuscore.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/librtMessage.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libxml2.so.2"
+            ],
+            "name": "/usr/lib/liblmapi.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbuscore.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/librtMessage.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libxml2.so.2"
+            ],
+            "name": "/usr/lib/liblmapi.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0"
+            ],
+            "name": "/usr/lib/liblog4c.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0"
+            ],
+            "name": "/usr/lib/liblog4c.so.3.3.0"
+        },
+        {
+            "apiversions": [
+                "XZ_5.0",
+                "XZ_5.2"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0"
+            ],
+            "name": "/usr/lib/liblzma.so.5"
+        },
+        {
+            "apiversions": [
+                "XZ_5.0",
+                "XZ_5.2"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0"
+            ],
+            "name": "/usr/lib/liblzma.so.5.2.6"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/liblzo2.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/liblzo2.so.2.0.0"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.4",
+                "GLIBC_2.15",
+                "GLIBC_2.18",
+                "GLIBC_2.23",
+                "GLIBC_2.24",
+                "GLIBC_2.25",
+                "GLIBC_2.27",
+                "GLIBC_2.28",
+                "GLIBC_2.29",
+                "GLIBC_2.31",
+                "GLIBC_2.32",
+                "GLIBC_2.35"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libm.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libmbedcrypto.so.2.16.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libmbedcrypto.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libmbedcrypto.so.3",
+                "/usr/lib/libmbedx509.so.0"
+            ],
+            "name": "/usr/lib/libmbedtls.so.12"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libmbedcrypto.so.3",
+                "/usr/lib/libmbedx509.so.0"
+            ],
+            "name": "/usr/lib/libmbedtls.so.2.16.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libmbedcrypto.so.3"
+            ],
+            "name": "/usr/lib/libmbedx509.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libmbedcrypto.so.3"
+            ],
+            "name": "/usr/lib/libmbedx509.so.2.16.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/libmbim-glib.so.4"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/libmbim-glib.so.4.6.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/libmm-glib.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0"
+            ],
+            "name": "/usr/lib/libmm-glib.so.0.8.0"
+        },
+        {
+            "apiversions": [
+                "LIBMNL_1.0",
+                "LIBMNL_1.1",
+                "LIBMNL_1.2"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libmnl.so.0"
+        },
+        {
+            "apiversions": [
+                "LIBMNL_1.0",
+                "LIBMNL_1.1",
+                "LIBMNL_1.2"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libmnl.so.0.2.0"
+        },
+        {
+            "apiversions": [
+                "MOSQ_1.0",
+                "MOSQ_1.1",
+                "MOSQ_1.2",
+                "MOSQ_1.3",
+                "MOSQ_1.4",
+                "MOSQ_1.5",
+                "MOSQ_1.6",
+                "MOSQ_1.7"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/libmosquitto.so.1"
+        },
+        {
+            "apiversions": [
+                "MOSQ_1.0",
+                "MOSQ_1.1",
+                "MOSQ_1.2",
+                "MOSQ_1.3",
+                "MOSQ_1.4",
+                "MOSQ_1.5",
+                "MOSQ_1.6",
+                "MOSQ_1.7"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/libmosquitto.so.2.0.14"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libmsgpackc.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libmsgpackc.so.2.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_mta.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libulog.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0"
+            ],
+            "name": "/usr/lib/libmta_tr181.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_mta.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libulog.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0"
+            ],
+            "name": "/usr/lib/libmta_tr181.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_mta.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libulog.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0"
+            ],
+            "name": "/usr/lib/libmta_tr181.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libnanomsg.so.5"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libnanomsg.so.5.1.0"
+        },
+        {
+            "apiversions": [
+                "NEON_0_29",
+                "NEON_0_30"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libexpat.so.1",
+                "/usr/lib/libproxy.so.1",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/libneon.so.27"
+        },
+        {
+            "apiversions": [
+                "NEON_0_29",
+                "NEON_0_30"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libexpat.so.1",
+                "/usr/lib/libproxy.so.1",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/libneon.so.27.3.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libnl-3.so.200",
+                "/usr/lib/libnl-nf-3.so.200",
+                "/usr/lib/libnl-route-3.so.200",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libnet.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libnl-3.so.200",
+                "/usr/lib/libnl-nf-3.so.200",
+                "/usr/lib/libnl-route-3.so.200",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libnet.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libmnl.so.0",
+                "/usr/lib/libnfnetlink.so.0"
+            ],
+            "name": "/usr/lib/libnetfilter_conntrack.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libmnl.so.0",
+                "/usr/lib/libnfnetlink.so.0"
+            ],
+            "name": "/usr/lib/libnetfilter_conntrack.so.3.8.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libmnl.so.0",
+                "/usr/lib/libnfnetlink.so.0"
+            ],
+            "name": "/usr/lib/libnetfilter_queue.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libmnl.so.0",
+                "/usr/lib/libnfnetlink.so.0"
+            ],
+            "name": "/usr/lib/libnetfilter_queue.so.1.5.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/libnetsnmp.so.40"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/libnetsnmp.so.40.1.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libnetsnmp.so.40"
+            ],
+            "name": "/usr/lib/libnetsnmpagent.so.40"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libnetsnmp.so.40"
+            ],
+            "name": "/usr/lib/libnetsnmpagent.so.40.1.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/libnetsnmphelpers.so.40"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/libnetsnmphelpers.so.40.1.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libnetsnmp.so.40",
+                "/usr/lib/libnetsnmpagent.so.40",
+                "/usr/lib/libpci.so.3"
+            ],
+            "name": "/usr/lib/libnetsnmpmibs.so.40"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libnetsnmp.so.40",
+                "/usr/lib/libnetsnmpagent.so.40",
+                "/usr/lib/libpci.so.3"
+            ],
+            "name": "/usr/lib/libnetsnmpmibs.so.40.1.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libnettle.so.4"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libnettle.so.4.7"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libnfnetlink.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libnfnetlink.so.0.2.0"
+        },
+        {
+            "apiversions": [
+                "libnl_3",
+                "libnl_3_2_26",
+                "libnl_3_2_27",
+                "libnl_3_2_28",
+                "libnl_3_2_29",
+                "libnl_3_5"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0"
+            ],
+            "name": "/usr/lib/libnl-3.so.200"
+        },
+        {
+            "apiversions": [
+                "libnl_3",
+                "libnl_3_2_26",
+                "libnl_3_2_27",
+                "libnl_3_2_28",
+                "libnl_3_2_29",
+                "libnl_3_5"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0"
+            ],
+            "name": "/usr/lib/libnl-3.so.200.26.0"
+        },
+        {
+            "apiversions": [
+                "libnl_3"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libnl-3.so.200"
+            ],
+            "name": "/usr/lib/libnl-genl-3.so.200"
+        },
+        {
+            "apiversions": [
+                "libnl_3"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libnl-3.so.200"
+            ],
+            "name": "/usr/lib/libnl-genl-3.so.200.26.0"
+        },
+        {
+            "apiversions": [
+                "libnl_3"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libnl-3.so.200",
+                "/usr/lib/libnl-route-3.so.200"
+            ],
+            "name": "/usr/lib/libnl-nf-3.so.200"
+        },
+        {
+            "apiversions": [
+                "libnl_3"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libnl-3.so.200",
+                "/usr/lib/libnl-route-3.so.200"
+            ],
+            "name": "/usr/lib/libnl-nf-3.so.200.26.0"
+        },
+        {
+            "apiversions": [
+                "libnl_3",
+                "libnl_3_2_26",
+                "libnl_3_2_27",
+                "libnl_3_2_28",
+                "libnl_3_2_29",
+                "libnl_3_4",
+                "libnl_3_5"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libnl-3.so.200"
+            ],
+            "name": "/usr/lib/libnl-route-3.so.200"
+        },
+        {
+            "apiversions": [
+                "libnl_3",
+                "libnl_3_2_26",
+                "libnl_3_2_27",
+                "libnl_3_2_28",
+                "libnl_3_2_29",
+                "libnl_3_4",
+                "libnl_3_5"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libnl-3.so.200"
+            ],
+            "name": "/usr/lib/libnl-route-3.so.200.26.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libnlohmann_json_schema_validator.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libnlohmann_json_schema_validator.so.2.1.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/libnopoll.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/libnopoll.so.0.0.0"
+        },
+        {
+            "apiversions": [
+                "LIBNSL_2.0",
+                "LIBNSL_PRIVATE"
+            ],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6",
+                "/usr/lib/libtirpc.so.3"
+            ],
+            "name": "/usr/lib/libnsl.so.3"
+        },
+        {
+            "apiversions": [
+                "LIBNSL_2.0",
+                "LIBNSL_PRIVATE"
+            ],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6",
+                "/usr/lib/libtirpc.so.3"
+            ],
+            "name": "/usr/lib/libnsl.so.3.0.0"
+        },
+        {
+            "apiversions": [
+                "GLIBC_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libnss_compat.so"
+        },
+        {
+            "apiversions": [
+                "GLIBC_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libnss_db.so"
+        },
+        {
+            "apiversions": [
+                "GLIBC_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libresolv.so.2"
+            ],
+            "name": "/usr/lib/libnss_hesiod.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libyajl.so.2"
+            ],
+            "name": "/usr/lib/libocispec.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libyajl.so.2"
+            ],
+            "name": "/usr/lib/libocispec.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libixml.so.2",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtirpc.so.3",
+                "/usr/lib/libupnp.so.6"
+            ],
+            "name": "/usr/lib/libpal.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libixml.so.2",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtirpc.so.3",
+                "/usr/lib/libupnp.so.6"
+            ],
+            "name": "/usr/lib/libpal.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libixml.so.2",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtirpc.so.3",
+                "/usr/lib/libupnp.so.6"
+            ],
+            "name": "/usr/lib/libpal.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libncursesw.so.5",
+                "/lib/libtinfo.so.5"
+            ],
+            "name": "/usr/lib/libpanelw.so.5"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libncursesw.so.5",
+                "/lib/libtinfo.so.5"
+            ],
+            "name": "/usr/lib/libpanelw.so.5.9"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libpcap.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libpcap.so.1.10.1"
+        },
+        {
+            "apiversions": [
+                "LIBPCI_3.0",
+                "LIBPCI_3.1",
+                "LIBPCI_3.2",
+                "LIBPCI_3.3",
+                "LIBPCI_3.4",
+                "LIBPCI_3.5",
+                "LIBPCI_3.6",
+                "LIBPCI_3.7"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libresolv.so.2",
+                "/lib/libudev.so.1",
+                "/lib/libz.so.1"
+            ],
+            "name": "/usr/lib/libpci.so.3"
+        },
+        {
+            "apiversions": [
+                "LIBPCI_3.0",
+                "LIBPCI_3.1",
+                "LIBPCI_3.2",
+                "LIBPCI_3.3",
+                "LIBPCI_3.4",
+                "LIBPCI_3.5",
+                "LIBPCI_3.6",
+                "LIBPCI_3.7"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libresolv.so.2",
+                "/lib/libudev.so.1",
+                "/lib/libz.so.1"
+            ],
+            "name": "/usr/lib/libpci.so.3.7.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libpcre.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libpcre.so.1.2.7"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libpcre2-8.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libpcre2-8.so.0.11.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libpcre2-8.so.0"
+            ],
+            "name": "/usr/lib/libpcre2-posix.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libpcre2-8.so.0"
+            ],
+            "name": "/usr/lib/libpcre2-posix.so.3.0.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libpcre32.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libpcre32.so.0.0.7"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libpcre.so.1"
+            ],
+            "name": "/usr/lib/libpcreposix.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libpcre.so.1"
+            ],
+            "name": "/usr/lib/libpcreposix.so.0.0.4"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/usr/lib/libcrypt.so.2"
+            ],
+            "name": "/usr/lib/libperl.so.5"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/usr/lib/libcrypt.so.2"
+            ],
+            "name": "/usr/lib/libperl.so.5.34.0"
+        },
+        {
+            "apiversions": [
+                "LIBPOPT_0"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libpopt.so.0"
+        },
+        {
+            "apiversions": [
+                "LIBPOPT_0"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libpopt.so.0.0.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtirpc.so.3"
+            ],
+            "name": "/usr/lib/libprint_uptime.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtirpc.so.3"
+            ],
+            "name": "/usr/lib/libprint_uptime.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtirpc.so.3"
+            ],
+            "name": "/usr/lib/libprint_uptime.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libcap.so.2",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6",
+                "/usr/lib/libjsoncpp.so.25",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libprivilege.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libcap.so.2",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6",
+                "/usr/lib/libjsoncpp.so.25",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libprivilege.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libcap.so.2",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6",
+                "/usr/lib/libjsoncpp.so.25",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libprivilege.so.0.0.0"
+        },
+        {
+            "apiversions": [
+                "LIBPROCPS_0"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libsystemd.so.0"
+            ],
+            "name": "/usr/lib/libprocps.so.8"
+        },
+        {
+            "apiversions": [
+                "LIBPROCPS_0"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libsystemd.so.0"
+            ],
+            "name": "/usr/lib/libprocps.so.8.0.3"
+        },
+        {
+            "apiversions": [
+                "LIBPROTOBUF_C_1.0.0",
+                "LIBPROTOBUF_C_1.3.0"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libprotobuf-c.so.1"
+        },
+        {
+            "apiversions": [
+                "LIBPROTOBUF_C_1.0.0",
+                "LIBPROTOBUF_C_1.3.0"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libprotobuf-c.so.1.0.0"
+        },
+        {
+            "apiversions": [
+                "LIBPROXY_0.4.16"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libproxy.so.1"
+        },
+        {
+            "apiversions": [
+                "LIBPROXY_0.4.16"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libproxy.so.1.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libproxy.so.1",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libproxy/0.4.17/modules/config_gnome3.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libicudata.so.70",
+                "/usr/lib/libicuuc.so.70"
+            ],
+            "name": "/usr/lib/libpsl.so.5"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libicudata.so.70",
+                "/usr/lib/libicuuc.so.70"
+            ],
+            "name": "/usr/lib/libpsl.so.5.3.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libpsx.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libpsx.so.2.65"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.4",
+                "GLIBC_2.11",
+                "GLIBC_2.12",
+                "GLIBC_2.18",
+                "GLIBC_2.28",
+                "GLIBC_2.30",
+                "GLIBC_2.31"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libpthread.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6"
+            ],
+            "name": "/usr/lib/libpython3.10.so.1.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmbim-glib.so.4"
+            ],
+            "name": "/usr/lib/libqmi-glib.so.5"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libmbim-glib.so.4"
+            ],
+            "name": "/usr/lib/libqmi-glib.so.5.8.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/librt.so.1",
+                "/usr/lib/libcrypt.so.2"
+            ],
+            "name": "/usr/lib/libquagga_pb.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/librt.so.1",
+                "/usr/lib/libcrypt.so.2"
+            ],
+            "name": "/usr/lib/libquagga_pb.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/librbuscore.so.0",
+                "/usr/lib/librtMessage.so.0"
+            ],
+            "name": "/usr/lib/librbus.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/librbuscore.so.0",
+                "/usr/lib/librtMessage.so.0"
+            ],
+            "name": "/usr/lib/librbus.so.2.0.13"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/librtMessage.so.0"
+            ],
+            "name": "/usr/lib/librbuscore.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/librtMessage.so.0"
+            ],
+            "name": "/usr/lib/librbuscore.so.2.0.13"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/librbusmethod.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/librbusmethod.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/librbusmethod.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libhostap.so.0",
+                "/usr/lib/libnl-3.so.200",
+                "/usr/lib/libnl-genl-3.so.200",
+                "/usr/lib/libnl-route-3.so.200",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/librdk_wifihal.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libhostap.so.0",
+                "/usr/lib/libnl-3.so.200",
+                "/usr/lib/libnl-genl-3.so.200",
+                "/usr/lib/libnl-route-3.so.200",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/librdk_wifihal.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/liblog4c.so.3",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/librdkloggers.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/liblog4c.so.3",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/librdkloggers.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/librdmopenssl.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/librdmopenssl.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libtinfo.so.5"
+            ],
+            "name": "/usr/lib/libreadline.so.5"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libtinfo.so.5"
+            ],
+            "name": "/usr/lib/libreadline.so.5.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libreportgen.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libreportgen.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libreportgen.so.0.0.0"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.4",
+                "GLIBC_2.9",
+                "GLIBC_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libresolv.so"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.4",
+                "GLIBC_2.7"
+            ],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/librt.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/librdkloggers.so.0"
+            ],
+            "name": "/usr/lib/librtMessage.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/librdkloggers.so.0"
+            ],
+            "name": "/usr/lib/librtMessage.so.2.0.13"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libsafec.so.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libsafec.so.3.0.7"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2utils.so.0"
+            ],
+            "name": "/usr/lib/libscheduler.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2utils.so.0"
+            ],
+            "name": "/usr/lib/libscheduler.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2utils.so.0"
+            ],
+            "name": "/usr/lib/libscheduler.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libseccomp.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libseccomp.so.2.4.3"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/librdkloggers.so.0"
+            ],
+            "name": "/usr/lib/libsecure_wrapper.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/librdkloggers.so.0"
+            ],
+            "name": "/usr/lib/libsecure_wrapper.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libnetsnmp.so.40",
+                "/usr/lib/libnetsnmpagent.so.40",
+                "/usr/lib/libnetsnmpmibs.so.40",
+                "/usr/lib/libprint_uptime.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsnmp_plugin.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0"
+            ],
+            "name": "/usr/lib/libsnmp_custom.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libnetsnmp.so.40",
+                "/usr/lib/libnetsnmpagent.so.40",
+                "/usr/lib/libnetsnmpmibs.so.40",
+                "/usr/lib/libprint_uptime.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsnmp_plugin.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0"
+            ],
+            "name": "/usr/lib/libsnmp_custom.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libnetsnmp.so.40",
+                "/usr/lib/libnetsnmpagent.so.40",
+                "/usr/lib/libnetsnmpmibs.so.40",
+                "/usr/lib/libprint_uptime.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsnmp_plugin.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0"
+            ],
+            "name": "/usr/lib/libsnmp_custom.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libnetsnmp.so.40",
+                "/usr/lib/libnetsnmpagent.so.40",
+                "/usr/lib/libnetsnmpmibs.so.40",
+                "/usr/lib/libprint_uptime.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0"
+            ],
+            "name": "/usr/lib/libsnmp_plugin.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libnetsnmp.so.40",
+                "/usr/lib/libnetsnmpagent.so.40",
+                "/usr/lib/libnetsnmpmibs.so.40",
+                "/usr/lib/libprint_uptime.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0"
+            ],
+            "name": "/usr/lib/libsnmp_plugin.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libnetsnmp.so.40",
+                "/usr/lib/libnetsnmpagent.so.40",
+                "/usr/lib/libnetsnmpmibs.so.40",
+                "/usr/lib/libprint_uptime.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0"
+            ],
+            "name": "/usr/lib/libsnmp_plugin.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgmodule-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libpsl.so.5",
+                "/usr/lib/libsqlite3.so.0",
+                "/usr/lib/libxml2.so.2"
+            ],
+            "name": "/usr/lib/libsoup-2.4.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgmodule-2.0.so.0",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libpsl.so.5",
+                "/usr/lib/libsqlite3.so.0",
+                "/usr/lib/libxml2.so.2"
+            ],
+            "name": "/usr/lib/libsoup-2.4.so.1.11.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libsqlite3.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libsqlite3.so.0.8.6"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtirpc.so.3",
+                "/usr/lib/libulog.so.0"
+            ],
+            "name": "/usr/lib/libsrvmgr.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtirpc.so.3",
+                "/usr/lib/libulog.so.0"
+            ],
+            "name": "/usr/lib/libsrvmgr.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtirpc.so.3",
+                "/usr/lib/libulog.so.0"
+            ],
+            "name": "/usr/lib/libsrvmgr.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libssa.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libsafec.so.3"
+            ],
+            "name": "/usr/lib/libssa.so.0.0.0"
+        },
+        {
+            "apiversions": [
+                "OPENSSL_3.0.0"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcrypto.so.3"
+            ],
+            "name": "/usr/lib/libssl.so.3"
+        },
+        {
+            "apiversions": [
+                "GLIBCXX_3.4",
+                "GLIBCXX_3.4.1",
+                "GLIBCXX_3.4.2",
+                "GLIBCXX_3.4.3",
+                "GLIBCXX_3.4.4",
+                "GLIBCXX_3.4.5",
+                "GLIBCXX_3.4.6",
+                "GLIBCXX_3.4.7",
+                "GLIBCXX_3.4.8",
+                "GLIBCXX_3.4.9",
+                "GLIBCXX_3.4.10",
+                "GLIBCXX_3.4.11",
+                "GLIBCXX_3.4.12",
+                "GLIBCXX_3.4.13",
+                "GLIBCXX_3.4.14",
+                "GLIBCXX_3.4.15",
+                "GLIBCXX_3.4.16",
+                "GLIBCXX_3.4.17",
+                "GLIBCXX_3.4.18",
+                "GLIBCXX_3.4.19",
+                "GLIBCXX_3.4.20",
+                "GLIBCXX_3.4.21",
+                "GLIBCXX_3.4.22",
+                "GLIBCXX_3.4.23",
+                "GLIBCXX_3.4.24",
+                "GLIBCXX_3.4.25",
+                "GLIBCXX_3.4.26",
+                "GLIBCXX_3.4.27",
+                "GLIBCXX_3.4.28",
+                "GLIBCXX_3.4.29",
+                "CXXABI_1.3",
+                "CXXABI_1.3.1",
+                "CXXABI_1.3.2",
+                "CXXABI_1.3.3",
+                "CXXABI_1.3.4",
+                "CXXABI_1.3.5",
+                "CXXABI_1.3.6",
+                "CXXABI_1.3.7",
+                "CXXABI_1.3.8",
+                "CXXABI_1.3.9",
+                "CXXABI_1.3.10",
+                "CXXABI_1.3.11",
+                "CXXABI_1.3.12",
+                "CXXABI_1.3.13",
+                "CXXABI_TM_1",
+                "CXXABI_ARM_1.3.3"
+            ],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6"
+            ],
+            "name": "/usr/lib/libstdc++.so"
+        },
+        {
+            "apiversions": [
+                "GLIBCXX_3.4",
+                "GLIBCXX_3.4.1",
+                "GLIBCXX_3.4.2",
+                "GLIBCXX_3.4.3",
+                "GLIBCXX_3.4.4",
+                "GLIBCXX_3.4.5",
+                "GLIBCXX_3.4.6",
+                "GLIBCXX_3.4.7",
+                "GLIBCXX_3.4.8",
+                "GLIBCXX_3.4.9",
+                "GLIBCXX_3.4.10",
+                "GLIBCXX_3.4.11",
+                "GLIBCXX_3.4.12",
+                "GLIBCXX_3.4.13",
+                "GLIBCXX_3.4.14",
+                "GLIBCXX_3.4.15",
+                "GLIBCXX_3.4.16",
+                "GLIBCXX_3.4.17",
+                "GLIBCXX_3.4.18",
+                "GLIBCXX_3.4.19",
+                "GLIBCXX_3.4.20",
+                "GLIBCXX_3.4.21",
+                "GLIBCXX_3.4.22",
+                "GLIBCXX_3.4.23",
+                "GLIBCXX_3.4.24",
+                "GLIBCXX_3.4.25",
+                "GLIBCXX_3.4.26",
+                "GLIBCXX_3.4.27",
+                "GLIBCXX_3.4.28",
+                "GLIBCXX_3.4.29",
+                "CXXABI_1.3",
+                "CXXABI_1.3.1",
+                "CXXABI_1.3.2",
+                "CXXABI_1.3.3",
+                "CXXABI_1.3.4",
+                "CXXABI_1.3.5",
+                "CXXABI_1.3.6",
+                "CXXABI_1.3.7",
+                "CXXABI_1.3.8",
+                "CXXABI_1.3.9",
+                "CXXABI_1.3.10",
+                "CXXABI_1.3.11",
+                "CXXABI_1.3.12",
+                "CXXABI_1.3.13",
+                "CXXABI_TM_1",
+                "CXXABI_ARM_1.3.3"
+            ],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6"
+            ],
+            "name": "/usr/lib/libstdc++.so.6"
+        },
+        {
+            "apiversions": [
+                "GLIBCXX_3.4",
+                "GLIBCXX_3.4.1",
+                "GLIBCXX_3.4.2",
+                "GLIBCXX_3.4.3",
+                "GLIBCXX_3.4.4",
+                "GLIBCXX_3.4.5",
+                "GLIBCXX_3.4.6",
+                "GLIBCXX_3.4.7",
+                "GLIBCXX_3.4.8",
+                "GLIBCXX_3.4.9",
+                "GLIBCXX_3.4.10",
+                "GLIBCXX_3.4.11",
+                "GLIBCXX_3.4.12",
+                "GLIBCXX_3.4.13",
+                "GLIBCXX_3.4.14",
+                "GLIBCXX_3.4.15",
+                "GLIBCXX_3.4.16",
+                "GLIBCXX_3.4.17",
+                "GLIBCXX_3.4.18",
+                "GLIBCXX_3.4.19",
+                "GLIBCXX_3.4.20",
+                "GLIBCXX_3.4.21",
+                "GLIBCXX_3.4.22",
+                "GLIBCXX_3.4.23",
+                "GLIBCXX_3.4.24",
+                "GLIBCXX_3.4.25",
+                "GLIBCXX_3.4.26",
+                "GLIBCXX_3.4.27",
+                "GLIBCXX_3.4.28",
+                "GLIBCXX_3.4.29",
+                "CXXABI_1.3",
+                "CXXABI_1.3.1",
+                "CXXABI_1.3.2",
+                "CXXABI_1.3.3",
+                "CXXABI_1.3.4",
+                "CXXABI_1.3.5",
+                "CXXABI_1.3.6",
+                "CXXABI_1.3.7",
+                "CXXABI_1.3.8",
+                "CXXABI_1.3.9",
+                "CXXABI_1.3.10",
+                "CXXABI_1.3.11",
+                "CXXABI_1.3.12",
+                "CXXABI_1.3.13",
+                "CXXABI_TM_1",
+                "CXXABI_ARM_1.3.3"
+            ],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6"
+            ],
+            "name": "/usr/lib/libstdc++.so.6.0.29"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0",
+                "/lib/libpam_misc.so.0",
+                "/usr/lib/libattr.so.1",
+                "/usr/lib/libcrypt.so.2"
+            ],
+            "name": "/usr/lib/libsubid.so.4"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0",
+                "/lib/libpam_misc.so.0",
+                "/usr/lib/libattr.so.1",
+                "/usr/lib/libcrypt.so.2"
+            ],
+            "name": "/usr/lib/libsubid.so.4.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtirpc.so.3",
+                "/usr/lib/libulog.so.0"
+            ],
+            "name": "/usr/lib/libsyscfg.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtirpc.so.3",
+                "/usr/lib/libulog.so.0"
+            ],
+            "name": "/usr/lib/libsyscfg.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtirpc.so.3",
+                "/usr/lib/libulog.so.0"
+            ],
+            "name": "/usr/lib/libsyscfg.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtirpc.so.3"
+            ],
+            "name": "/usr/lib/libsysevent.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtirpc.so.3"
+            ],
+            "name": "/usr/lib/libsysevent.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtirpc.so.3"
+            ],
+            "name": "/usr/lib/libsysevent.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libccspinterface.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2utils.so.0"
+            ],
+            "name": "/usr/lib/libt2parser.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libccspinterface.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2utils.so.0"
+            ],
+            "name": "/usr/lib/libt2parser.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libccspinterface.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2utils.so.0"
+            ],
+            "name": "/usr/lib/libt2parser.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libt2utils.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libt2utils.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libt2utils.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2utils.so.0"
+            ],
+            "name": "/usr/lib/libtelemetry_msgsender.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2utils.so.0"
+            ],
+            "name": "/usr/lib/libtelemetry_msgsender.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2utils.so.0"
+            ],
+            "name": "/usr/lib/libtelemetry_msgsender.so.0.0.0"
+        },
+        {
+            "apiversions": [
+                "GLIBC_2.4"
+            ],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libthread_db.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libthreadutil.so.6"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libthreadutil.so.6.0.4"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libtime_conversion.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libtime_conversion.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libtime_conversion.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/libtinyxml.so.2.6.2"
+        },
+        {
+            "apiversions": [
+                "TIRPC_0.3.0",
+                "TIRPC_0.3.1",
+                "TIRPC_0.3.2",
+                "TIRPC_0.3.3",
+                "TIRPC_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0"
+            ],
+            "name": "/usr/lib/libtirpc.so.3"
+        },
+        {
+            "apiversions": [
+                "TIRPC_0.3.0",
+                "TIRPC_0.3.1",
+                "TIRPC_0.3.2",
+                "TIRPC_0.3.3",
+                "TIRPC_PRIVATE"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0"
+            ],
+            "name": "/usr/lib/libtirpc.so.3.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libHotspotApi.so.0",
+                "/usr/lib/libapi_dhcpv4c.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcm_mgnt.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libfw_upgrade.so.0",
+                "/usr/lib/libhal_ethsw.so.0",
+                "/usr/lib/libhal_moca.so.0",
+                "/usr/lib/libhal_msomgmt.so.0",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/liblibparodus.so",
+                "/usr/lib/liblmapi.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtime_conversion.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libwebconfig_framework.so.0",
+                "/usr/lib/libwrp-c.so"
+            ],
+            "name": "/usr/lib/libtr181.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libHotspotApi.so.0",
+                "/usr/lib/libapi_dhcpv4c.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcm_mgnt.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libfw_upgrade.so.0",
+                "/usr/lib/libhal_ethsw.so.0",
+                "/usr/lib/libhal_moca.so.0",
+                "/usr/lib/libhal_msomgmt.so.0",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/liblibparodus.so",
+                "/usr/lib/liblmapi.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtime_conversion.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libwebconfig_framework.so.0",
+                "/usr/lib/libwrp-c.so"
+            ],
+            "name": "/usr/lib/libtr181.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libHotspotApi.so.0",
+                "/usr/lib/libapi_dhcpv4c.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcm_mgnt.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libfw_upgrade.so.0",
+                "/usr/lib/libhal_ethsw.so.0",
+                "/usr/lib/libhal_moca.so.0",
+                "/usr/lib/libhal_msomgmt.so.0",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/liblibparodus.so",
+                "/usr/lib/liblmapi.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtime_conversion.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libwebconfig_framework.so.0",
+                "/usr/lib/libwrp-c.so"
+            ],
+            "name": "/usr/lib/libtr181.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/libtrower-base64.so.1.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libucresolv.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtirpc.so.3"
+            ],
+            "name": "/usr/lib/libulog.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtirpc.so.3"
+            ],
+            "name": "/usr/lib/libulog.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtirpc.so.3"
+            ],
+            "name": "/usr/lib/libulog.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libunistring.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libunistring.so.2.2.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libunwind.so.8"
+            ],
+            "name": "/usr/lib/libunwind-arm.so.8"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libunwind.so.8"
+            ],
+            "name": "/usr/lib/libunwind-arm.so.8.0.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1"
+            ],
+            "name": "/usr/lib/libunwind-coredump.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1"
+            ],
+            "name": "/usr/lib/libunwind-coredump.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1"
+            ],
+            "name": "/usr/lib/libunwind-ptrace.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1"
+            ],
+            "name": "/usr/lib/libunwind-ptrace.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libunwind-arm.so.8",
+                "/usr/lib/libunwind.so.8"
+            ],
+            "name": "/usr/lib/libunwind-setjmp.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libunwind-arm.so.8",
+                "/usr/lib/libunwind.so.8"
+            ],
+            "name": "/usr/lib/libunwind-setjmp.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1"
+            ],
+            "name": "/usr/lib/libunwind.so.8"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1"
+            ],
+            "name": "/usr/lib/libunwind.so.8.0.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libixml.so.2",
+                "/usr/lib/libthreadutil.so.6"
+            ],
+            "name": "/usr/lib/libupnp.so.6"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libixml.so.2",
+                "/usr/lib/libthreadutil.so.6"
+            ],
+            "name": "/usr/lib/libupnp.so.6.3.6"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcm_mgnt.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libffi.so.8",
+                "/usr/lib/libgcrypt.so.20",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgmodule-2.0.so.0",
+                "/usr/lib/libgnutls.so.28",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libgpg-error.so.0",
+                "/usr/lib/libgssdp-1.2.so.0",
+                "/usr/lib/libgthread-2.0.so.0",
+                "/usr/lib/libgupnp-1.0.so.4",
+                "/usr/lib/libhal_ethsw.so.0",
+                "/usr/lib/libhal_moca.so.0",
+                "/usr/lib/libhal_msomgmt.so.0",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/liblmapi.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsoup-2.4.so.1",
+                "/usr/lib/libsqlite3.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libxml2.so.2"
+            ],
+            "name": "/usr/lib/libupnpidm.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcm_mgnt.so.0",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libffi.so.8",
+                "/usr/lib/libgcrypt.so.20",
+                "/usr/lib/libgio-2.0.so.0",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libgmodule-2.0.so.0",
+                "/usr/lib/libgnutls.so.28",
+                "/usr/lib/libgobject-2.0.so.0",
+                "/usr/lib/libgpg-error.so.0",
+                "/usr/lib/libgssdp-1.2.so.0",
+                "/usr/lib/libgthread-2.0.so.0",
+                "/usr/lib/libgupnp-1.0.so.4",
+                "/usr/lib/libhal_ethsw.so.0",
+                "/usr/lib/libhal_moca.so.0",
+                "/usr/lib/libhal_msomgmt.so.0",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/liblmapi.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsoup-2.4.so.1",
+                "/usr/lib/libsqlite3.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libxml2.so.2"
+            ],
+            "name": "/usr/lib/libupnpidm.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtirpc.so.3",
+                "/usr/lib/libulog.so.0"
+            ],
+            "name": "/usr/lib/libutapi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtirpc.so.3",
+                "/usr/lib/libulog.so.0"
+            ],
+            "name": "/usr/lib/libutapi.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtirpc.so.3",
+                "/usr/lib/libulog.so.0"
+            ],
+            "name": "/usr/lib/libutapi.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtirpc.so.3",
+                "/usr/lib/libulog.so.0"
+            ],
+            "name": "/usr/lib/libutctx.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtirpc.so.3",
+                "/usr/lib/libulog.so.0"
+            ],
+            "name": "/usr/lib/libutctx.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsyscfg.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtirpc.so.3",
+                "/usr/lib/libulog.so.0"
+            ],
+            "name": "/usr/lib/libutctx.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtirpc.so.3"
+            ],
+            "name": "/usr/lib/libutopiautil.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtirpc.so.3"
+            ],
+            "name": "/usr/lib/libutopiautil.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libhal_platform.so.0",
+                "/usr/lib/libnanomsg.so.5",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libtirpc.so.3"
+            ],
+            "name": "/usr/lib/libutopiautil.so.0.0.0"
+        },
+        {
+            "apiversions": [
+                "UUID_1.0",
+                "UUID_2.20",
+                "UUID_2.31",
+                "UUID_2.36",
+                "UUIDD_PRIVATE"
+            ],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libuuid.so.1"
+        },
+        {
+            "apiversions": [
+                "UUID_1.0",
+                "UUID_2.20",
+                "UUID_2.31",
+                "UUID_2.36",
+                "UUIDD_PRIVATE"
+            ],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libuuid.so.1.3.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libwdmp-c.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbuscore.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/librtMessage.so.0"
+            ],
+            "name": "/usr/lib/libwebconfig_framework.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbuscore.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/librtMessage.so.0"
+            ],
+            "name": "/usr/lib/libwebconfig_framework.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/lib/librt.so.1",
+                "/lib/libz.so.1",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librbuscore.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/librtMessage.so.0"
+            ],
+            "name": "/usr/lib/libwebconfig_framework.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libavro.so.23",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libev.so.4",
+                "/usr/lib/libhal_wifi.so.0",
+                "/usr/lib/liblibparodus.so",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprint_uptime.so.0",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libuuid.so.1",
+                "/usr/lib/libwebconfig_framework.so.0",
+                "/usr/lib/libwifi_webconfig.so.0"
+            ],
+            "name": "/usr/lib/libwifi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libavro.so.23",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libev.so.4",
+                "/usr/lib/libhal_wifi.so.0",
+                "/usr/lib/liblibparodus.so",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprint_uptime.so.0",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libuuid.so.1",
+                "/usr/lib/libwebconfig_framework.so.0",
+                "/usr/lib/libwifi_webconfig.so.0"
+            ],
+            "name": "/usr/lib/libwifi.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libavro.so.23",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libev.so.4",
+                "/usr/lib/libhal_wifi.so.0",
+                "/usr/lib/liblibparodus.so",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprint_uptime.so.0",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libsysevent.so.0",
+                "/usr/lib/libtelemetry_msgsender.so.0",
+                "/usr/lib/libtrower-base64.so.1.0.0",
+                "/usr/lib/libutapi.so.0",
+                "/usr/lib/libutctx.so.0",
+                "/usr/lib/libuuid.so.1",
+                "/usr/lib/libwebconfig_framework.so.0",
+                "/usr/lib/libwifi_webconfig.so.0"
+            ],
+            "name": "/usr/lib/libwifi.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libsystemd.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libjansson.so.4",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libssl.so.3",
+                "/usr/lib/libwebconfig_framework.so.0"
+            ],
+            "name": "/usr/lib/libwifi_webconfig.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libsystemd.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libjansson.so.4",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libssl.so.3",
+                "/usr/lib/libwebconfig_framework.so.0"
+            ],
+            "name": "/usr/lib/libwifi_webconfig.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/lib/libsystemd.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libjansson.so.4",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/libsafec.so.3",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libssl.so.3",
+                "/usr/lib/libwebconfig_framework.so.0"
+            ],
+            "name": "/usr/lib/libwifi_webconfig.so.0.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libwpa_client.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcimplog.so.1.0.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libtrower-base64.so.1.0.0"
+            ],
+            "name": "/usr/lib/libwrp-c.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libccspinterface.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2parser.so.0",
+                "/usr/lib/libt2utils.so.0"
+            ],
+            "name": "/usr/lib/libxconfclient.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libccspinterface.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2parser.so.0",
+                "/usr/lib/libt2utils.so.0"
+            ],
+            "name": "/usr/lib/libxconfclient.so.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpthread.so.0",
+                "/usr/lib/libbreakpadwrapper.so.0",
+                "/usr/lib/libccsp_common.so.0",
+                "/usr/lib/libccspinterface.so.0",
+                "/usr/lib/libcjson.so.1",
+                "/usr/lib/libcurl.so.4",
+                "/usr/lib/libdbus-1.so.3",
+                "/usr/lib/libglib-2.0.so.0",
+                "/usr/lib/libmsgpackc.so.2",
+                "/usr/lib/libprivilege.so.0",
+                "/usr/lib/librbus.so.0",
+                "/usr/lib/librdkloggers.so.0",
+                "/usr/lib/libsecure_wrapper.so.0",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libt2parser.so.0",
+                "/usr/lib/libt2utils.so.0"
+            ],
+            "name": "/usr/lib/libxconfclient.so.0.0.0"
+        },
+        {
+            "apiversions": [
+                "LIBXML2_2.4.30",
+                "LIBXML2_2.5.0",
+                "LIBXML2_2.5.2",
+                "LIBXML2_2.5.4",
+                "LIBXML2_2.5.5",
+                "LIBXML2_2.5.6",
+                "LIBXML2_2.5.7",
+                "LIBXML2_2.5.8",
+                "LIBXML2_2.5.9",
+                "LIBXML2_2.6.0",
+                "LIBXML2_2.6.1",
+                "LIBXML2_2.6.2",
+                "LIBXML2_2.6.3",
+                "LIBXML2_2.6.5",
+                "LIBXML2_2.6.6",
+                "LIBXML2_2.6.7",
+                "LIBXML2_2.6.8",
+                "LIBXML2_2.6.10",
+                "LIBXML2_2.6.11",
+                "LIBXML2_2.6.12",
+                "LIBXML2_2.6.14",
+                "LIBXML2_2.6.15",
+                "LIBXML2_2.6.16",
+                "LIBXML2_2.6.17",
+                "LIBXML2_2.6.18",
+                "LIBXML2_2.6.19",
+                "LIBXML2_2.6.20",
+                "LIBXML2_2.6.21",
+                "LIBXML2_2.6.23",
+                "LIBXML2_2.6.24",
+                "LIBXML2_2.6.25",
+                "LIBXML2_2.6.27",
+                "LIBXML2_2.6.28",
+                "LIBXML2_2.6.29",
+                "LIBXML2_2.6.32",
+                "LIBXML2_2.7.0",
+                "LIBXML2_2.7.3",
+                "LIBXML2_2.7.4",
+                "LIBXML2_2.8.0",
+                "LIBXML2_2.9.0",
+                "LIBXML2_2.9.1",
+                "LIBXML2_2.9.8",
+                "LIBXML2_2.9.11"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6",
+                "/lib/libz.so.1"
+            ],
+            "name": "/usr/lib/libxml2.so.2"
+        },
+        {
+            "apiversions": [
+                "LIBXML2_2.4.30",
+                "LIBXML2_2.5.0",
+                "LIBXML2_2.5.2",
+                "LIBXML2_2.5.4",
+                "LIBXML2_2.5.5",
+                "LIBXML2_2.5.6",
+                "LIBXML2_2.5.7",
+                "LIBXML2_2.5.8",
+                "LIBXML2_2.5.9",
+                "LIBXML2_2.6.0",
+                "LIBXML2_2.6.1",
+                "LIBXML2_2.6.2",
+                "LIBXML2_2.6.3",
+                "LIBXML2_2.6.5",
+                "LIBXML2_2.6.6",
+                "LIBXML2_2.6.7",
+                "LIBXML2_2.6.8",
+                "LIBXML2_2.6.10",
+                "LIBXML2_2.6.11",
+                "LIBXML2_2.6.12",
+                "LIBXML2_2.6.14",
+                "LIBXML2_2.6.15",
+                "LIBXML2_2.6.16",
+                "LIBXML2_2.6.17",
+                "LIBXML2_2.6.18",
+                "LIBXML2_2.6.19",
+                "LIBXML2_2.6.20",
+                "LIBXML2_2.6.21",
+                "LIBXML2_2.6.23",
+                "LIBXML2_2.6.24",
+                "LIBXML2_2.6.25",
+                "LIBXML2_2.6.27",
+                "LIBXML2_2.6.28",
+                "LIBXML2_2.6.29",
+                "LIBXML2_2.6.32",
+                "LIBXML2_2.7.0",
+                "LIBXML2_2.7.3",
+                "LIBXML2_2.7.4",
+                "LIBXML2_2.8.0",
+                "LIBXML2_2.9.0",
+                "LIBXML2_2.9.1",
+                "LIBXML2_2.9.8",
+                "LIBXML2_2.9.11"
+            ],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libm.so.6",
+                "/lib/libz.so.1"
+            ],
+            "name": "/usr/lib/libxml2.so.2.9.14"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libxtables.so.12"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libxtables.so.12.4.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libyajl.so.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libyajl.so.2.1.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/librt.so.1",
+                "/usr/lib/libcrypt.so.2"
+            ],
+            "name": "/usr/lib/libzebra.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/librt.so.1",
+                "/usr/lib/libcrypt.so.2"
+            ],
+            "name": "/usr/lib/libzebra.so.1.0.0"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libzstd.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/libzstd.so.1.5.2"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/mod_access.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/mod_accesslog.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/mod_alias.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/mod_auth.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcrypto.so.3"
+            ],
+            "name": "/usr/lib/mod_authn_file.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/mod_cgi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libpcre.so.1"
+            ],
+            "name": "/usr/lib/mod_dirlisting.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/mod_fastcgi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/mod_indexfile.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/mod_openssl.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/mod_proxy.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libpcre.so.1"
+            ],
+            "name": "/usr/lib/mod_redirect.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libpcre.so.1"
+            ],
+            "name": "/usr/lib/mod_rewrite.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcrypto.so.3"
+            ],
+            "name": "/usr/lib/mod_secdownload.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/mod_setenv.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/mod_ssi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/mod_staticfile.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcrypto.so.3"
+            ],
+            "name": "/usr/lib/ossl-modules/legacy.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/plugins/dobby/libIpcPlugin.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/lib/libsystemd.so.0",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/plugins/dobby/libLoggingPlugin.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/plugins/dobby/libMinidumpPlugin.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libnl-3.so.200",
+                "/usr/lib/libnl-route-3.so.200",
+                "/usr/lib/libstdc++.so.6",
+                "/usr/lib/libyajl.so.2"
+            ],
+            "name": "/usr/lib/plugins/dobby/libNetworkingPlugin.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/plugins/dobby/libOOMCrashPlugin.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6",
+                "/lib/libgcc_s.so.1",
+                "/usr/lib/libstdc++.so.6"
+            ],
+            "name": "/usr/lib/plugins/dobby/libStoragePlugin.so.1"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_asyncio.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/python3.10/lib-dynload/_bisect.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_blake2.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libbz2.so.1"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_bz2.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_codecs_cn.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_codecs_hk.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_codecs_iso2022.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_codecs_jp.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_codecs_kr.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_codecs_tw.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/python3.10/lib-dynload/_contextvars.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcrypt.so.2"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_crypt.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/python3.10/lib-dynload/_csv.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libffi.so.8"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_ctypes.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_ctypes_test.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libncursesw.so.5",
+                "/lib/libtinfo.so.5"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_curses.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libpanelw.so.5"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_curses_panel.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_datetime.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libgdbm_compat.so.3"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_dbm.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_decimal.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_elementtree.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcrypto.so.3"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_hashlib.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/python3.10/lib-dynload/_heapq.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/python3.10/lib-dynload/_json.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/python3.10/lib-dynload/_lsprof.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/liblzma.so.5"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_lzma.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_md5.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_multibytecodec.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_multiprocessing.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/python3.10/lib-dynload/_opcode.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_pickle.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_posixshmem.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_posixsubprocess.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/python3.10/lib-dynload/_queue.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_random.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_sha1.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_sha256.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_sha3.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_sha512.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_socket.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libsqlite3.so.0"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_sqlite3.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libcrypto.so.3",
+                "/usr/lib/libssl.so.3"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_ssl.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/python3.10/lib-dynload/_statistics.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_struct.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_testbuffer.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_testcapi.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/python3.10/lib-dynload/_testimportmultiple.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_testinternalcapi.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/python3.10/lib-dynload/_testmultiphase.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libuuid.so.1"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_uuid.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_xxsubinterpreters.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_xxtestfuzz.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/_zoneinfo.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/array.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/audioop.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/binascii.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/cmath.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/fcntl.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/grp.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/math.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/mmap.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libnsl.so.3",
+                "/usr/lib/libtirpc.so.3"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/nis.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/ossaudiodev.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/pyexpat.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libreadline.so.5"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/readline.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/resource.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/select.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/spwd.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/syslog.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/termios.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/unicodedata.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/python3.10/lib-dynload/xxlimited.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/python3.10/lib-dynload/xxlimited_35.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libz.so.1"
+            ],
+            "name": "/usr/lib/python3.10/lib-dynload/zlib.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/ld-linux-armhf.so.3",
+                "/lib/libc.so.6",
+                "/usr/lib/libffi.so.8"
+            ],
+            "name": "/usr/lib/python3.10/site-packages/_cffi_backend.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6"
+            ],
+            "name": "/usr/lib/python3.10/site-packages/bcrypt/_bcrypt.abi3.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [],
+            "name": "/usr/lib/python3.10/site-packages/zope/interface/_zope_interface_coptimizations.cpython-310-arm-linux-gnueabi.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libpam.so.0",
+                "/lib/libpam_misc.so.0",
+                "/usr/lib/libecryptfs.so.1",
+                "/usr/lib/libgcrypt.so.20",
+                "/usr/lib/libkeyutils.so.1"
+            ],
+            "name": "/usr/lib/security/pam_ecryptfs.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_DNAT.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_DNPT.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_HL.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_LOG.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_MASQUERADE.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_NETMAP.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_REDIRECT.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_REJECT.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_SNAT.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_SNPT.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_ah.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_dst.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_eui64.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_frag.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_hbh.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_hl.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_icmp6.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_ipv6header.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_mh.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_rt.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libip6t_srh.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libipt_CLUSTERIP.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libipt_DNAT.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libipt_ECN.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libipt_LOG.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libipt_MASQUERADE.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libipt_NETMAP.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libipt_REDIRECT.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libipt_REJECT.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libipt_SNAT.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libipt_TRIGGER.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libipt_TTL.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libipt_ULOG.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libipt_ah.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libipt_icmp.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libipt_realm.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libipt_ttl.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_AUDIT.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_CHECKSUM.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_CLASSIFY.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_CONNMARK.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_CONNSECMARK.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_CT.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_DSCP.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_HMARK.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_IDLETIMER.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_LED.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_MARK.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_NFLOG.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_NFQUEUE.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_NOTRACK.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_RATEEST.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_SECMARK.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_SET.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_SYNPROXY.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_TCPMSS.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_TCPOPTSTRIP.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_TEE.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_TOS.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_TPROXY.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_TRACE.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_addrtype.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_bpf.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_cgroup.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_cluster.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_comment.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_connbytes.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_connlimit.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_connmark.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_conntrack.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_cpu.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_dccp.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_devgroup.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_dscp.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_ecn.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_esp.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_hashlimit.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_helper.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_ipcomp.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_iprange.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_ipvs.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_length.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_limit.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_mac.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_mark.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_multiport.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_nfacct.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_osf.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_owner.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_physdev.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_pkttype.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_policy.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_quota.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_rateest.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_recent.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_rpfilter.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_sctp.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_set.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_socket.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_standard.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_state.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/lib/libm.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_statistic.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_string.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_tcp.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_tcpmss.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_time.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_tos.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_u32.so"
+        },
+        {
+            "apiversions": [],
+            "deps": [
+                "/lib/libc.so.6",
+                "/usr/lib/libxtables.so.12"
+            ],
+            "name": "/usr/lib/xtables/libxt_udp.so"
+        }
+    ]
+}


### PR DESCRIPTION
Reason for change : Creating the json files to support RPI4 kirkstone both 32 bit and 64 bit broadband bundles
Test procedure : Created oci bundles and tested with DobbyTool
Risk : Low