### PR TITLE
RDKBACCL-975 : Provide command line args for iperf3 app

### DIFF
--- a/bundlegen/core/bundle_processor.py
+++ b/bundlegen/core/bundle_processor.py
@@ -19,6 +19,7 @@ import os
 import json
 import humanfriendly
 import textwrap
+import shlex
 from jsonschema import validate
 from hashlib import sha256
 from loguru import logger
@@ -461,6 +462,15 @@ class BundleProcessor:
                 dobbyinitpath = self.platform_cfg['dobby']['dobbyInitPath']
             else:
                 dobbyinitpath = '/usr/libexec/DobbyInit'
+            args = self.oci_config['process']['args']
+            new_args = []
+            for item in args:
+                if ' ' in item:
+                    item = item.replace('\\@', ' ')
+                    new_args.extend(shlex.split(item))
+                else:
+                    new_args.append(item)
+            self.oci_config['process']['args'] = new_args
 
             # Add DobbyInit to start of arguments
             self.oci_config['process']['args'].insert(0, dobbyinitpath)


### PR DESCRIPTION
Reason for change: made changes to split single argument as multiple arugments for config.json of a bundle
Test Procedure: UspPa -c operate "Device.SoftwareModules.InstallDU(URL=http://192.168.2.51/iperf3argsjul255.tar)"
 UspPa -c operate "Device.SoftwareModules.ExecutionUnit.1.SetRequestedState(RequestedState=Active)"
Risks: None