### PR TITLE
RDKBACCL-1300 : speedtest container not starting

### DIFF
--- a/bundlegen/core/bundle_processor.py
+++ b/bundlegen/core/bundle_processor.py
@@ -463,10 +463,11 @@ class BundleProcessor:
             else:
                 dobbyinitpath = '/usr/libexec/DobbyInit'
             args = self.oci_config['process']['args']
+
             new_args = []
             for item in args:
+                item = item.replace('\\@', ' ')
                 if ' ' in item:
-                    item = item.replace('\\@', ' ')
                     new_args.extend(shlex.split(item))
                 else:
                     new_args.append(item)


### PR DESCRIPTION
Reason for change : item value and its loop adjusted properly for arguments alignment in config.json
Test Procedure : generate the bundle , check the config.json file
Risks: None