### PR TITLE
RDKBACCL-1234: Updating libethanlog.so in bpir4_reference.json

### DIFF
--- a/templates/generic/bpir4_reference.json
+++ b/templates/generic/bpir4_reference.json
@@ -81,6 +81,17 @@
             ],
             "type": "bind"
         },
+        {
+            "source": "/usr/lib/libethanlog.so.3",
+            "destination": "/usr/lib/libethanlog.so.3",
+            "options": [
+                "rbind",
+                "nosuid",
+                "nodev",
+                "ro"
+            ],
+            "type": "bind"
+        },
        {
             "source": "tmpfs",
             "destination": "/tmp",


### PR DESCRIPTION
Reason for change: To fix the App failure due to libethanlog
Test procedure: Checked iperf as DAC application
Risks: Low