### PR TITLE
RDKBACCL-976: integrate & build rdk-speedtest-cli with meta-dac-sdk-broadband & test with DAC

### DIFF
--- a/templates/generic/bpir4_reference.json
+++ b/templates/generic/bpir4_reference.json
@@ -92,16 +92,25 @@
             ],
             "type": "bind"
         },
-       {
-            "source": "tmpfs",
+        {
+            "destination": "/rdklogs",
+            "type": "bind",
+            "source": "/rdklogs",
+            "options": [
+                "rbind",
+                "rw"
+	    ]
+        },
+        {
+            "source": "/tmp",
             "destination": "/tmp",
             "options": [
+                "rbind",
                 "nosuid",
-                "strictatime",
-                "mode=755",
-                "size=65536k"
+                "nodev",
+                "rw"
             ],
-            "type": "tmpfs"
+            "type": "bind"
         }
     ],
     "network": {


### PR DESCRIPTION
Reason for change: Building the speedtest cli with dac layer and running as a bundle
Test procedure: Test the bundle using usp-pa commands and check the iperf telemetry markers is updated in the could
Risks: Low